### PR TITLE
feat(module): improve param validation

### DIFF
--- a/pallets/subspace/src/global.rs
+++ b/pallets/subspace/src/global.rs
@@ -321,6 +321,6 @@ impl<T: Config> Pallet<T> {
     }
 
     pub fn rm_from_whitelist(module_key: &T::AccountId) {
-        LegitWhitelist::<T>::remove(&module_key);
+        LegitWhitelist::<T>::remove(module_key);
     }
 }

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -280,9 +280,9 @@ impl<T: Config> Pallet<T> {
     }
 
     // TODO: see if we can optimize this further
-    pub fn does_module_name_exist(netuid: u16, name: Vec<u8>) -> bool {
+    pub fn does_module_name_exist(netuid: u16, name: &[u8]) -> bool {
         <Name<T> as IterableStorageDoubleMap<u16, u16, Vec<u8>>>::iter_prefix(netuid)
-            .any(|(_uid, _name)| _name == name)
+            .any(|(_, existing)| existing == name)
     }
 
     pub fn is_subnet_founder(netuid: u16, key: &T::AccountId) -> bool {
@@ -616,37 +616,18 @@ impl<T: Config> Pallet<T> {
         let uid = Self::get_uid_for_key(netuid, key);
         Self::get_emission_for_uid(netuid, uid)
     }
+
     pub fn get_emission_for_uid(netuid: u16, uid: u16) -> u64 {
-        let vec = Emission::<T>::get(netuid);
-        if (uid as usize) < vec.len() {
-            vec[uid as usize]
-        } else {
-            0
-        }
+        Emission::<T>::get(netuid).get(uid as usize).copied().unwrap_or_default()
     }
     pub fn get_incentive_for_uid(netuid: u16, uid: u16) -> u16 {
-        let vec = Incentive::<T>::get(netuid);
-        if (uid as usize) < vec.len() {
-            vec[uid as usize]
-        } else {
-            0
-        }
+        Incentive::<T>::get(netuid).get(uid as usize).copied().unwrap_or_default()
     }
     pub fn get_dividends_for_uid(netuid: u16, uid: u16) -> u16 {
-        let vec = Dividends::<T>::get(netuid);
-        if (uid as usize) < vec.len() {
-            vec[uid as usize]
-        } else {
-            0
-        }
+        Dividends::<T>::get(netuid).get(uid as usize).copied().unwrap_or_default()
     }
     pub fn get_last_update_for_uid(netuid: u16, uid: u16) -> u64 {
-        let vec = LastUpdate::<T>::get(netuid);
-        if (uid as usize) < vec.len() {
-            vec[uid as usize]
-        } else {
-            0
-        }
+        LastUpdate::<T>::get(netuid).get(uid as usize).copied().unwrap_or_default()
     }
 
     pub fn get_global_max_allowed_subnets() -> u16 {

--- a/pallets/subspace/tests/weights.rs
+++ b/pallets/subspace/tests/weights.rs
@@ -1,7 +1,7 @@
 mod mock;
 use frame_support::{assert_err, assert_ok};
 
-use pallet_subspace::{Error, GlobalParams};
+use pallet_subspace::Error;
 use sp_core::U256;
 use sp_runtime::DispatchError;
 


### PR DESCRIPTION
This commit changes how we validate module params, making it impossible to create invalid addresses, names, or repeated names when updating an existing module. The checks are now in one place.