### PR TITLE
feat: making code more robust, fixing incentives

### DIFF
--- a/pallets/subspace/src/global.rs
+++ b/pallets/subspace/src/global.rs
@@ -141,10 +141,6 @@ impl<T: Config> Pallet<T> {
         Nominator::<T>::put(nominator)
     }
 
-    pub fn get_registrations_this_interval() -> u16 {
-        RegistrationsThisInterval::<T>::get()
-    }
-
     pub fn get_target_registrations_per_interval() -> u16 {
         TargetRegistrationsPerInterval::<T>::get()
     }
@@ -191,16 +187,6 @@ impl<T: Config> Pallet<T> {
     }
     pub fn set_burn_rate(burn_rate: u16) {
         BurnRate::<T>::put(burn_rate.min(100));
-    }
-
-    pub fn get_burn() -> u64 {
-        Burn::<T>::get()
-    }
-
-    pub fn set_burn(burn: u64) {
-        Burn::<T>::set(burn);
-        // announce a burn change
-        Self::deposit_event(Event::RegistrationBurnChanged(burn));
     }
 
     pub fn get_max_proposals() -> u64 {

--- a/pallets/subspace/src/global.rs
+++ b/pallets/subspace/src/global.rs
@@ -10,6 +10,7 @@ impl<T: Config> Pallet<T> {
     pub fn global_params() -> GlobalParams<T> {
         GlobalParams {
             max_name_length: Self::get_global_max_name_length(),
+            min_name_length: Self::get_global_min_name_length(),
             max_allowed_subnets: Self::get_global_max_allowed_subnets(),
             max_allowed_modules: Self::get_max_allowed_modules(),
             max_registrations_per_block: Self::get_max_registrations_per_block(),
@@ -38,6 +39,11 @@ impl<T: Config> Pallet<T> {
 
         // check if the name already exists
         ensure!(params.max_name_length > 0, Error::<T>::InvalidMaxNameLength);
+
+        ensure!(
+            params.min_name_length < params.max_name_length,
+            Error::<T>::InvalidMinNameLenght
+        );
 
         // we need to ensure that the delegation fee floor is only moven up, moving it down would
         // require a storage migration
@@ -226,6 +232,14 @@ impl<T: Config> Pallet<T> {
 
     pub fn set_global_max_name_length(max_name_length: u16) {
         MaxNameLength::<T>::put(max_name_length)
+    }
+
+    pub fn get_global_min_name_length() -> u16 {
+        MinNameLength::<T>::get()
+    }
+
+    pub fn set_global_min_name_length(min_name_length: u16) {
+        MinNameLength::<T>::put(min_name_length)
     }
 
     pub fn do_update_global(origin: T::RuntimeOrigin, params: GlobalParams<T>) -> DispatchResult {

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "512"]
 
+use crate::subnet::SubnetSet;
 use frame_system::{self as system, ensure_signed};
 pub use pallet::*;
 
@@ -168,6 +169,15 @@ pub mod pallet {
         StorageValue<_, u16, ValueQuery, DefaultMaxNameLength<T>>;
 
     #[pallet::type_value]
+    pub fn DefaultMinNameLength<T: Config>() -> u16 {
+        2
+    }
+
+    #[pallet::storage]
+    pub(super) type MinNameLength<T: Config> =
+        StorageValue<_, u16, ValueQuery, DefaultMinNameLength<T>>;
+
+    #[pallet::type_value]
     pub fn DefaultMaxAllowedSubnets<T: Config>() -> u16 {
         256
     }
@@ -270,6 +280,7 @@ pub mod pallet {
         pub burn_rate: u16,
         // max
         pub max_name_length: u16,             // max length of a network name
+        pub min_name_length: u16,             // min length of a network name
         pub max_allowed_subnets: u16,         // max number of subnets allowed
         pub max_allowed_modules: u16,         // max number of modules allowed per subnet
         pub max_registrations_per_block: u16, // max number of registrations per block
@@ -345,6 +356,7 @@ pub mod pallet {
             target_registrations_per_interval: DefaultTargetRegistrationsPerInterval::<T>::get(),
             target_registrations_interval: DefaultTargetRegistrationsInterval::<T>::get(),
             max_name_length: DefaultMaxNameLength::<T>::get(),
+            min_name_length: DefaultMinNameLength::<T>::get(),
             max_proposals: DefaultMaxProposals::<T>::get(),
             min_burn: DefaultMinBurn::<T>::get(),
             max_burn: DefaultMaxBurn::<T>::get(),
@@ -871,6 +883,7 @@ pub mod pallet {
         TxRateLimitSet(u64), // --- Event created when setting the transaction rate limit.
         UnitEmissionSet(u64), // --- Event created when setting the unit emission
         MaxNameLengthSet(u16), // --- Event created when setting the maximum network name length
+        MinNameLenghtSet(u16), // --- Event created when setting the minimum network name length
         MaxAllowedSubnetsSet(u16), // --- Event created when setting the maximum allowed subnets
         MaxAllowedModulesSet(u16), // --- Event created when setting the maximum allowed modules
         MaxRegistrationsPerBlockSet(u16), // --- Event created when we set max registrations
@@ -939,10 +952,13 @@ pub mod pallet {
                               * transactions. */
         InvalidMaxAllowedUids, /* --- Thrown when the user tries to set max allowed uids to a
                                 * value less than the current number of registered uids. */
+        NetuidDoesNotExist,
         SubnetNameAlreadyExists,
+        SubnetNameTooShort,
+        SubnetNameTooLong,
+        InvalidSubnetName,
         BalanceNotAdded,
         StakeNotRemoved,
-        SubnetNameNotExists,
         KeyAlreadyRegistered, //
         EmptyKeys,
         NotNominator, /* --- Thrown when the user tries to set the nominator and is not the
@@ -976,6 +992,7 @@ pub mod pallet {
         InvalidMinDelegationFee,
 
         InvalidMaxNameLength,
+        InvalidMinNameLenght,
         InvalidMaxAllowedSubnets,
         InvalidMaxAllowedModules,
         InvalidMaxRegistrationsPerBlock,
@@ -992,6 +1009,7 @@ pub mod pallet {
         // Modules
         /// The module name is too long.
         ModuleNameTooLong,
+        ModuleNameTooShort,
         /// The module name is invalid. It has to be a UTF-8 encoded string.
         InvalidModuleName,
         /// The address is too long.
@@ -1053,7 +1071,7 @@ pub mod pallet {
 
                 let default_params = self::Pallet::<T>::default_subnet_params();
 
-                let params = SubnetParams {
+                let params: SubnetParams<T> = SubnetParams {
                     name: subnet.0.clone(),
                     tempo: subnet.1,
                     immunity_period: subnet.2,
@@ -1072,7 +1090,9 @@ pub mod pallet {
                     max_weight_age: default_params.max_weight_age,
                 };
 
-                self::Pallet::<T>::add_subnet(params, None);
+                let changeset: SubnetSet<T> =
+                    SubnetSet::new(&params.name, &params.founder, params.clone());
+                self::Pallet::<T>::add_subnet(changeset, Some(netuid));
 
                 for (uid_usize, (key, name, address, weights)) in
                     self.modules[subnet_idx].iter().enumerate()
@@ -1370,8 +1390,9 @@ pub mod pallet {
             // Check if subnet parameters are valid
             Self::check_subnet_params(&params)?;
 
+            let subnet_set = SubnetSet::new(&params.name, &params.founder, params.clone());
             // if so update them
-            Self::do_update_subnet(origin, netuid, params)
+            Self::do_update_subnet(origin, netuid, subnet_set)
         }
 
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -175,22 +175,14 @@ pub mod pallet {
     pub(super) type MaxAllowedSubnets<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultMaxAllowedSubnets<T>>;
 
-    #[pallet::type_value]
-    pub fn DefaultRegistrationsThisInterval<T: Config>() -> u16 {
-        0
-    }
-
-    #[pallet::storage] // --- ITEM ( registrations_this_interval )
+    #[pallet::storage]
+    // --- MAP (netuid) --> registrations_this_interval
     pub(super) type RegistrationsThisInterval<T: Config> =
-        StorageValue<_, u16, ValueQuery, DefaultRegistrationsThisInterval<T>>;
+        StorageMap<_, Identity, u16, u16, ValueQuery>;
 
-    #[pallet::type_value]
-    pub fn DefaultBurn<T: Config>() -> u64 {
-        0
-    }
-
-    #[pallet::storage] // --- ITEM ( burn )
-    pub(super) type Burn<T: Config> = StorageValue<_, u64, ValueQuery, DefaultBurn<T>>;
+    #[pallet::storage]
+    // --- MAP (netuid) --> burn
+    pub(super) type Burn<T: Config> = StorageMap<_, Identity, u16, u64, ValueQuery>;
 
     #[pallet::type_value]
     pub fn DefaultMaxAllowedModules<T: Config>() -> u16 {

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -64,7 +64,7 @@ pub mod pallet {
     use sp_arithmetic::per_things::Percent;
     pub use sp_std::{vec, vec::Vec};
 
-    const STORAGE_VERSION: StorageVersion = StorageVersion::new(1);
+    const STORAGE_VERSION: StorageVersion = StorageVersion::new(2);
 
     #[pallet::pallet]
     #[pallet::generate_store(pub(super) trait Store)]

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![recursion_limit = "512"]
 
-use crate::subnet::SubnetSet;
+use crate::subnet::SubnetChangeset;
 use frame_system::{self as system, ensure_signed};
 pub use pallet::*;
 
@@ -1090,8 +1090,8 @@ pub mod pallet {
                     max_weight_age: default_params.max_weight_age,
                 };
 
-                let changeset: SubnetSet<T> =
-                    SubnetSet::new(&params.name, &params.founder, params.clone());
+                let changeset: SubnetChangeset<T> =
+                    SubnetChangeset::new(&params.name, &params.founder, params.clone());
                 self::Pallet::<T>::add_subnet(changeset, Some(netuid));
 
                 for (uid_usize, (key, name, address, weights)) in
@@ -1390,7 +1390,8 @@ pub mod pallet {
             // Check if subnet parameters are valid
             Self::check_subnet_params(&params)?;
 
-            let subnet_set = SubnetSet::new(&params.name, &params.founder, params.clone());
+            let subnet_set =
+                SubnetChangeset::update(&params.name, &params.founder, netuid, params.clone());
             // if so update them
             Self::do_update_subnet(origin, netuid, subnet_set)
         }

--- a/pallets/subspace/src/module.rs
+++ b/pallets/subspace/src/module.rs
@@ -1,5 +1,8 @@
 use super::*;
-use frame_support::pallet_prelude::{Decode, DispatchResult, Encode};
+use frame_support::{
+    pallet_prelude::{Decode, DispatchResult, Encode},
+    IterableStorageDoubleMap,
+};
 
 extern crate alloc;
 use alloc::vec::Vec;
@@ -58,10 +61,12 @@ impl ModuleChangeset {
         uid: u16,
     ) -> Result<(), sp_runtime::DispatchError> {
         let max = MaxNameLength::<T>::get() as usize;
-
+        let min = MinNameLength::<T>::get() as usize;
+        
         if let Some(name) = self.name {
             ensure!(!name.is_empty(), Error::<T>::InvalidModuleName);
             ensure!(name.len() <= max, Error::<T>::ModuleNameTooLong);
+            ensure!(name.len() >= min, Error::<T>::ModuleNameTooShort);
             core::str::from_utf8(&name).map_err(|_| Error::<T>::InvalidModuleName)?;
             ensure!(
                 !Pallet::<T>::does_module_name_exist(netuid, &name),
@@ -104,6 +109,11 @@ impl<T: Config> Pallet<T> {
         changeset.apply::<T>(netuid, key, uid)?;
 
         Ok(())
+    }
+
+    pub fn does_module_name_exist(netuid: u16, name: &[u8]) -> bool {
+        <Name<T> as IterableStorageDoubleMap<u16, u16, Vec<u8>>>::iter_prefix(netuid)
+            .any(|(_, existing)| existing == name)
     }
 
     pub fn module_params(netuid: u16, key: &T::AccountId) -> ModuleParams<T> {

--- a/pallets/subspace/src/module.rs
+++ b/pallets/subspace/src/module.rs
@@ -62,7 +62,7 @@ impl ModuleChangeset {
     ) -> Result<(), sp_runtime::DispatchError> {
         let max = MaxNameLength::<T>::get() as usize;
         let min = MinNameLength::<T>::get() as usize;
-        
+
         if let Some(name) = self.name {
             ensure!(!name.is_empty(), Error::<T>::InvalidModuleName);
             ensure!(name.len() <= max, Error::<T>::ModuleNameTooLong);

--- a/pallets/subspace/src/registration.rs
+++ b/pallets/subspace/src/registration.rs
@@ -98,7 +98,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 5. Ensure the caller has enough stake to register.
         let min_stake: u64 = MinStake::<T>::get(netuid);
-        let current_burn: u64 = Self::get_burn();
+        let current_burn: u64 = Self::get_burn(netuid);
         // also ensures that in the case current_burn is present, the stake is enough
         // as burn, will be decreased from the stake on the module
         ensure!(
@@ -137,7 +137,9 @@ impl<T: Config> Pallet<T> {
 
         // --- 10. Increment the number of registrations.
         RegistrationsPerBlock::<T>::mutate(|val| *val += 1);
-        RegistrationsThisInterval::<T>::mutate(|val| *val += 1);
+        RegistrationsThisInterval::<T>::mutate(netuid, |registrations| {
+            *registrations = registrations.saturating_add(1);
+        });
 
         // --- Deposit successful event.
         Self::deposit_event(Event::ModuleRegistered(netuid, uid, module_key));

--- a/pallets/subspace/src/registration.rs
+++ b/pallets/subspace/src/registration.rs
@@ -1,4 +1,4 @@
-use crate::{module::ModuleChangeset, subnet::SubnetSet};
+use crate::{module::ModuleChangeset, subnet::SubnetChangeset};
 
 use super::*;
 
@@ -94,9 +94,10 @@ impl<T: Config> Pallet<T> {
                 founder: key.clone(),
                 ..Self::default_subnet_params()
             };
-            let subnet_set: SubnetSet<T> = SubnetSet::new(&network_name, &key, params);
+            let subnet_changeset: SubnetChangeset<T> =
+                SubnetChangeset::new(&network_name, &key, params);
             // Create subnet if it does not exist.
-            Self::add_subnet_from_registration(stake, subnet_set)?
+            Self::add_subnet_from_registration(stake, subnet_changeset)?
         };
 
         // --- 5. Ensure the caller has enough stake to register.
@@ -228,7 +229,7 @@ impl<T: Config> Pallet<T> {
 
     pub fn add_subnet_from_registration(
         stake: u64,
-        subnetset: SubnetSet<T>,
+        changeset: SubnetChangeset<T>,
     ) -> Result<u16, sp_runtime::DispatchError> {
         let num_subnets: u16 = Self::num_subnets();
         let max_subnets: u16 = Self::get_global_max_allowed_subnets();
@@ -243,7 +244,7 @@ impl<T: Config> Pallet<T> {
             None
         };
 
-        Ok(Self::add_subnet(subnetset, target_subnet))
+        Ok(Self::add_subnet(changeset, target_subnet))
     }
 
     pub fn check_module_limits(netuid: u16) {

--- a/pallets/subspace/src/step.rs
+++ b/pallets/subspace/src/step.rs
@@ -9,13 +9,13 @@ impl<T: Config> Pallet<T> {
         let block_number: u64 = Self::get_current_block_number();
         RegistrationsPerBlock::<T>::mutate(|val| *val = 0);
 
-        let registration_this_interval = Self::get_registrations_this_interval();
-
-        // adjust registrations parameters
-        Self::adjust_registration(block_number, registration_this_interval);
-
         log::debug!("block_step for block: {:?} ", block_number);
         for (netuid, tempo) in <Tempo<T> as IterableStorageMap<u16, u16>>::iter() {
+            let registration_this_interval = Self::get_registrations_this_interval(netuid);
+
+            // adjust registrations parameters
+            Self::adjust_registration(netuid, block_number, registration_this_interval);
+
             let new_queued_emission: u64 = Self::calculate_network_emission(netuid);
             PendingEmission::<T>::mutate(netuid, |queued| *queued += new_queued_emission);
             log::debug!(
@@ -575,19 +575,23 @@ impl<T: Config> Pallet<T> {
         burn_amount_per_epoch
     }
 
-    pub fn adjust_registration(block_number: u64, registrations_this_interval: u16) {
+    pub fn adjust_registration(netuid: u16, block_number: u64, registrations_this_interval: u16) {
         let target_registrations_interval = Self::get_target_registrations_interval();
         if block_number % u64::from(target_registrations_interval) == 0 {
-            let current_burn = Self::get_burn();
+            let current_burn = Self::get_burn(netuid);
             let target_registrations_per_interval = Self::get_target_registrations_per_interval();
 
-            Self::set_burn(Self::adjust_burn(
-                current_burn,
-                registrations_this_interval,
-                target_registrations_per_interval,
-            ));
+            Self::set_burn(
+                netuid,
+                Self::adjust_burn(
+                    current_burn,
+                    registrations_this_interval,
+                    target_registrations_per_interval,
+                ),
+            );
 
-            RegistrationsThisInterval::<T>::mutate(|val| *val = 0);
+            // reset the registrations
+            Self::set_registrations_this_interval(netuid, 0);
         }
     }
 

--- a/pallets/subspace/src/step.rs
+++ b/pallets/subspace/src/step.rs
@@ -581,14 +581,13 @@ impl<T: Config> Pallet<T> {
             let current_burn = Self::get_burn(netuid);
             let target_registrations_per_interval = Self::get_target_registrations_per_interval();
 
-            Self::set_burn(
-                netuid,
-                Self::adjust_burn(
-                    current_burn,
-                    registrations_this_interval,
-                    target_registrations_per_interval,
-                ),
+            let adjusted_burn = Self::adjust_burn(
+                current_burn,
+                registrations_this_interval,
+                target_registrations_per_interval,
             );
+
+            Self::set_burn(netuid, adjusted_burn);
 
             // reset the registrations
             Self::set_registrations_this_interval(netuid, 0);

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -413,6 +413,11 @@ impl<T: Config> Pallet<T> {
         TotalSubnets::<T>::mutate(|n| *n += 1);
         N::<T>::insert(netuid, 0);
 
+        // Insert the minimum burn to the netuid,
+        // to prevent free registrations the first target registration interval.
+        let min_burn = Self::get_min_burn();
+        Burn::<T>::insert(netuid, min_burn);
+
         // --- 6. Emit the new network event.
         Self::deposit_event(Event::NetworkAdded(netuid, name));
 

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -36,8 +36,8 @@ impl<T: Config> SubnetChangeset<T> {
     ) -> Self {
         let old_params = Pallet::<T>::subnet_params(netuid);
         Self {
-            name: (name != &old_params.name).then_some(name.to_vec()),
-            founder_key: (founder_key != &old_params.founder).then_some(founder_key.clone()),
+            name: (name != old_params.name).then_some(name.to_vec()),
+            founder_key: (*founder_key != old_params.founder).then_some(founder_key.clone()),
             params: (!params.eq(&old_params)).then_some(params),
         }
     }

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -185,6 +185,8 @@ impl<T: Config> Pallet<T> {
         N::<T>::contains_key(netuid)
     }
 
+    // stake
+
     #[cfg(debug_assertions)]
     pub fn get_min_stake(netuid: u16) -> u64 {
         MinStake::<T>::get(netuid)
@@ -196,6 +198,23 @@ impl<T: Config> Pallet<T> {
 
     pub fn set_max_stake(netuid: u16, stake: u64) {
         MaxStake::<T>::insert(netuid, stake)
+    }
+
+    // registrations
+    pub fn get_registrations_this_interval(netuid: u16) -> u16 {
+        RegistrationsThisInterval::<T>::get(netuid)
+    }
+
+    pub fn set_registrations_this_interval(netuid: u16, registrations: u16) {
+        RegistrationsThisInterval::<T>::insert(netuid, registrations);
+    }
+
+    pub fn get_burn(netuid: u16) -> u64 {
+        Burn::<T>::get(netuid)
+    }
+
+    pub fn set_burn(netuid: u16, burn: u64) {
+        Burn::<T>::insert(netuid, burn);
     }
 
     // get the least staked network

--- a/pallets/subspace/tests/delegate_staking.rs
+++ b/pallets/subspace/tests/delegate_staking.rs
@@ -16,6 +16,9 @@ fn test_ownership_ratio() {
         let num_modules: u16 = 10;
         let tempo = 1;
         let stake_per_module: u64 = 1_000_000_000;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         register_n_modules(netuid, num_modules, stake_per_module);
         SubspaceModule::set_tempo(netuid, tempo);
 

--- a/pallets/subspace/tests/profit_share.rs
+++ b/pallets/subspace/tests/profit_share.rs
@@ -13,6 +13,9 @@ fn test_add_profit_share() {
         let netuid = 0;
         let miner_key = U256::from(0);
         let voter_key = U256::from(1);
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         register_module(netuid, miner_key, 1_000_000_000).expect("register miner module failed");
         register_module(netuid, voter_key, 1_000_000_000).expect("register voter module failed");
         let miner_uid = SubspaceModule::get_uid_for_key(netuid, &miner_key);

--- a/pallets/subspace/tests/registration.rs
+++ b/pallets/subspace/tests/registration.rs
@@ -19,6 +19,8 @@ fn test_min_stake() {
         let min_stake = 100_000_000;
         let max_registrations_per_block = 10;
         let reg_this_block: u16 = 100;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         register_module(netuid, U256::from(0), 0).expect("register module failed");
         SubspaceModule::set_min_stake(netuid, min_stake);
@@ -53,6 +55,8 @@ fn test_max_registration() {
         let min_stake = 100_000_000;
         let rounds = 3;
         let max_registrations_per_block = 100;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         SubspaceModule::set_min_stake(netuid, min_stake);
         SubspaceModule::set_max_registrations_per_block(max_registrations_per_block);
@@ -83,6 +87,9 @@ fn test_delegate_register() {
         let key: U256 = U256::from(n + 1);
         let module_keys: Vec<U256> = (0..n).map(U256::from).collect();
         let stake_amount: u64 = 10_000_000_000;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         SubspaceModule::add_balance_to_account(&key, stake_amount * n as u64);
         for module_key in module_keys {
             delegate_register_module(netuid, key, module_key, stake_amount)
@@ -102,6 +109,8 @@ fn test_registration_ok() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 0;
         let key: U256 = U256::from(1);
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         register_module(netuid, key, 0)
             .unwrap_or_else(|_| panic!("register module failed for key {key:?}"));
@@ -127,6 +136,9 @@ fn test_many_registrations() {
         let netuid = 0;
         let stake = 10;
         let n = 100;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         SubspaceModule::set_max_registrations_per_block(n);
         for i in 0..n {
             register_module(netuid, U256::from(i), stake).unwrap_or_else(|_| {
@@ -146,6 +158,9 @@ fn test_registration_with_stake() {
     new_test_ext().execute_with(|| {
         let netuid = 0;
         let stake_vector: Vec<u64> = [100000, 1000000, 10000000].to_vec();
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         for (i, stake) in stake_vector.iter().enumerate() {
             let uid: u16 = i as u16;
@@ -171,6 +186,9 @@ fn register_same_key_twice() {
         let netuid = 0;
         let stake = 10;
         let key = U256::from(1);
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         assert_ok!(register_module(netuid, key, stake));
         assert_err!(
             register_module(netuid, key, stake),
@@ -230,6 +248,8 @@ fn test_validation_cases(f: impl Fn(&[u8], &[u8]) -> DispatchResult) {
 #[test]
 fn validates_module_on_registration() {
     new_test_ext().execute_with(|| {
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         test_validation_cases(|name, addr| register_custom(0, 0.into(), name, addr));
 
         assert_err!(
@@ -245,6 +265,9 @@ fn validates_module_on_update() {
         let subnet = 0;
         let key_0: U256 = 0.into();
         let origin_0 = get_origin(0.into());
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         assert_ok!(register_custom(subnet, key_0, b"test", b"0.0.0.0:1"));
 
         test_validation_cases(|name, addr| {

--- a/pallets/subspace/tests/staking.rs
+++ b/pallets/subspace/tests/staking.rs
@@ -17,6 +17,8 @@ fn test_stake() {
         let amount_staked_vector: Vec<u64> = netuids.iter().map(|_| to_nano(10)).collect();
         let mut total_stake: u64 = 0;
         let mut subnet_stake: u64 = 0;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         for netuid in netuids {
             info!("NETUID: {}", netuid);
@@ -91,6 +93,8 @@ fn test_multiple_stake() {
         let _uid: u16 = 0;
         let num_staked_modules: u16 = 10;
         let total_stake: u64 = stake_amount * num_staked_modules as u64;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         register_n_modules(netuid, n, 0);
         let controler_key = U256::from(n + 1);
@@ -164,6 +168,8 @@ fn test_transfer_stake() {
         let _uid: u16 = 0;
         let num_staked_modules: u16 = 10;
         let _total_stake: u64 = stake_amount * num_staked_modules as u64;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         register_n_modules(netuid, n, stake_amount);
 
@@ -205,6 +211,8 @@ fn test_delegate_stake() {
         let amount_staked_vector: Vec<u64> = netuids.iter().map(|_i| to_nano(10)).collect();
         let mut total_stake: u64 = 0;
         let mut subnet_stake: u64 = 0;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         for i in netuids.iter() {
             let netuid = *i;
@@ -306,6 +314,9 @@ fn test_ownership_ratio() {
         let netuid: u16 = 0;
         let num_modules: u16 = 10;
         let stake_per_module: u64 = 1_000_000_000;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         register_n_modules(netuid, num_modules, 0);
 
         let keys = SubspaceModule::get_keys(netuid);
@@ -369,6 +380,8 @@ fn test_min_stake() {
         let netuid: u16 = 0;
         let num_modules: u16 = 10;
         let min_stake: u64 = 10_000_000_000;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         register_n_modules(netuid, num_modules, min_stake);
         let keys = SubspaceModule::get_keys(netuid);

--- a/pallets/subspace/tests/step.rs
+++ b/pallets/subspace/tests/step.rs
@@ -34,6 +34,9 @@ fn check_network_stats(netuid: u16) {
 fn test_stale_weights() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 0;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         register_n_modules(0, 10, 1000);
         let _subnet_params = SubspaceModule::subnet_params(netuid);
         let _keys = SubspaceModule::get_keys(netuid);
@@ -45,6 +48,10 @@ fn test_stale_weights() {
 fn test_no_weights() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 0;
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         register_n_modules(0, 10, 1000);
         SubspaceModule::set_tempo(netuid, 1);
         let _keys = SubspaceModule::get_keys(netuid);
@@ -68,6 +75,9 @@ fn test_dividends_same_stake() {
         let _n_list: Vec<u16> = vec![10, 50, 100, 1000];
         let _blocks_per_epoch_list: u64 = 1;
         let stake_per_module: u64 = 10_000;
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         // SETUP NETWORK
         register_n_modules(netuid, n, stake_per_module);
@@ -155,6 +165,9 @@ fn test_dividends_diff_stake() {
         let stake_per_module: u64 = 10_000;
         let tempo: u16 = 100;
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         // SETUP NETWORK
         for i in 0..n {
             let mut stake = stake_per_module;
@@ -237,6 +250,9 @@ fn test_pruning() {
         let stake_per_module: u64 = 10_000;
         let tempo: u16 = 100;
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         // SETUP NETWORK
         register_n_modules(netuid, n, stake_per_module);
         SubspaceModule::set_max_allowed_modules(n);
@@ -304,6 +320,9 @@ fn test_lowest_priority_mechanism() {
         let _blocks_per_epoch_list: u64 = 1;
         let stake_per_module: u64 = 10_000;
         let tempo: u16 = 100;
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         // SETUP NETWORK
         register_n_modules(netuid, n, stake_per_module);
@@ -494,6 +513,9 @@ fn test_incentives() {
         let _blocks_per_epoch_list: u64 = 1;
         let stake_per_module: u64 = 10_000;
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         // SETUP NETWORK
         register_n_modules(netuid, n, stake_per_module);
         let mut params = SubspaceModule::subnet_params(netuid);
@@ -553,9 +575,10 @@ fn test_trust() {
         let _n_list: Vec<u16> = vec![10, 50, 100, 1000];
         let _blocks_per_epoch_list: u64 = 1;
         let stake_per_module: u64 = 10_000;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         // SETUP NETWORK
-
         register_n_modules(netuid, n, stake_per_module);
         let mut params = SubspaceModule::subnet_params(netuid);
         params.min_allowed_weights = 1;
@@ -915,6 +938,15 @@ fn test_founder_share() {
 #[test]
 fn test_dynamic_burn() {
     new_test_ext().execute_with(|| {
+        let netuid = 0;
+        let initial_stake: u64 = 1000;
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
+        // Create the subnet
+        let subnet_key = U256::from(2050);
+        assert_ok!(register_module(netuid, subnet_key, initial_stake));
         // Using the default GlobalParameters:
         // - registration target interval = 2 * tempo (200 blocks)
         // - registration target for interval = registration_target_interval / 2
@@ -929,22 +961,9 @@ fn test_dynamic_burn() {
         params.target_registrations_per_interval = 100;
         SubspaceModule::set_global_params(params);
 
-        let netuid = 0;
-        let initial_stake: u64 = 1000;
-
-        // Create the subnet
-        let subnet_key = U256::from(2050);
-        assert_ok!(register_module(netuid, subnet_key, initial_stake));
-
-        // Make sure we are starting with no burn
-        assert!(
-            SubspaceModule::get_burn(netuid) == 0,
-            "start burn: {:?}",
-            SubspaceModule::get_burn(netuid)
-        );
-
-        // Step 2 epochs to wait for the burn to get updated to the min_burn
+        // update the burn to the minimum
         step_block(200);
+
         assert!(
             SubspaceModule::get_burn(netuid) == SubspaceModule::get_min_burn(),
             "current burn: {:?}",

--- a/pallets/subspace/tests/step.rs
+++ b/pallets/subspace/tests/step.rs
@@ -916,7 +916,7 @@ fn test_founder_share() {
 fn test_dynamic_burn() {
     new_test_ext().execute_with(|| {
         // Using the default GlobalParameters:
-        // - registration target interval =  2 * tempo (200 blocks)
+        // - registration target interval = 2 * tempo (200 blocks)
         // - registration target for interval = registration_target_interval / 2
         // - adjustment alpha = 0
         // - min_burn = 2 $COMAI
@@ -928,62 +928,62 @@ fn test_dynamic_burn() {
         params.target_registrations_interval = 200;
         params.target_registrations_per_interval = 100;
         SubspaceModule::set_global_params(params);
+
         let netuid = 0;
-        // first register 1000 modules (10 * the default registration target interval)
-        // this is 5 modules per block
-        let n: usize = 1000;
-        // second registration wave registers just 50 modules
-        let n2: usize = 50;
         let initial_stake: u64 = 1000;
-        let keys: Vec<U256> = (0..n).map(U256::from).collect();
-        let keys2: Vec<U256> = (n + 1..n + 1 + n2).map(U256::from).collect();
-        let stakes: Vec<u64> = (0..n).map(|_x: usize| initial_stake * 1_000_000_000).collect();
 
-        // make sure we are starting with no burn
+        // Create the subnet
+        let subnet_key = U256::from(2050);
+        assert_ok!(register_module(netuid, subnet_key, initial_stake));
+
+        // Make sure we are starting with no burn
         assert!(
-            SubspaceModule::get_burn() == 0,
+            SubspaceModule::get_burn(netuid) == 0,
             "start burn: {:?}",
-            SubspaceModule::get_burn()
+            SubspaceModule::get_burn(netuid)
         );
 
-        // step 2 epochs to wait for the burn to get updated to the min_burn
-
+        // Step 2 epochs to wait for the burn to get updated to the min_burn
         step_block(200);
-
         assert!(
-            SubspaceModule::get_burn() == SubspaceModule::get_min_burn(),
+            SubspaceModule::get_burn(netuid) == SubspaceModule::get_min_burn(),
             "current burn: {:?}",
-            SubspaceModule::get_burn()
+            SubspaceModule::get_burn(netuid)
         );
 
-        // register the first 1000 modules, this 10x the registration target
+        // Register the first 1000 modules, this is 10x the registration target
         let registrations_per_block = 5;
+        let n: usize = 1000;
+        let stakes: Vec<u64> = (0..n).map(|_| initial_stake * 1_000_000_000).collect();
         for i in 0..n {
-            assert_ok!(register_module(netuid, keys[i], stakes[i]));
+            let key = U256::from(i);
+            assert_ok!(register_module(netuid, key, stakes[i]));
             if (i + 1) % registrations_per_block == 0 {
                 step_block(1);
             }
         }
 
-        // burn is now at 11 instead of 2
+        // Burn is now at 11 instead of 2
         assert!(
-            SubspaceModule::get_burn() == to_nano(11),
+            SubspaceModule::get_burn(netuid) == to_nano(11),
             "current burn {:?}",
-            SubspaceModule::get_burn()
+            SubspaceModule::get_burn(netuid)
         );
 
-        // register only half of the target
+        // Register only half of the target
+        let n2: usize = 50;
         for i in 0..n2 {
-            assert_ok!(register_module(netuid, keys2[i], stakes[i]));
+            let key = U256::from(n + i);
+            assert_ok!(register_module(netuid, key, stakes[i]));
         }
 
         step_block(200);
 
-        // make sure the burn correctly decreased base on demand
+        // Make sure the burn correctly decreased based on demand
         assert!(
-            SubspaceModule::get_burn() == 8250000000,
+            SubspaceModule::get_burn(netuid) == 8250000000,
             "current burn: {:?}",
-            SubspaceModule::get_burn()
+            SubspaceModule::get_burn(netuid)
         );
     });
 }

--- a/pallets/subspace/tests/step.rs
+++ b/pallets/subspace/tests/step.rs
@@ -269,7 +269,7 @@ fn test_pruning() {
 
         step_block(tempo);
 
-        let lowest_priority_uid: u16 = SubspaceModule::get_lowest_uid(netuid);
+        let lowest_priority_uid: u16 = SubspaceModule::get_lowest_uid(netuid, false);
         assert!(lowest_priority_uid == prune_uid);
 
         let new_key: U256 = U256::from(n + 1);
@@ -348,7 +348,7 @@ fn test_lowest_priority_mechanism() {
         assert!(incentives[prune_uid as usize] == 0);
         assert!(dividends[prune_uid as usize] == 0);
 
-        let lowest_priority_uid: u16 = SubspaceModule::get_lowest_uid(netuid);
+        let lowest_priority_uid: u16 = SubspaceModule::get_lowest_uid(netuid, false);
         info!("lowest_priority_uid: {lowest_priority_uid}");
         info!("prune_uid: {prune_uid}");
         info!("emissions: {emissions:?}");

--- a/pallets/subspace/tests/subnet.rs
+++ b/pallets/subspace/tests/subnet.rs
@@ -272,7 +272,26 @@ fn test_set_max_allowed_uids_shrinking() {
 
         let mut params = SubspaceModule::subnet_params(netuid).clone();
         params.max_allowed_uids = max_uids;
-        let result = SubspaceModule::do_update_subnet(get_origin(keys[0]), netuid, params);
+        params.name = "test2".as_bytes().to_vec();
+        let result = SubspaceModule::update_subnet(
+            get_origin(keys[0]),
+            netuid,
+            params.founder,
+            params.founder_share,
+            params.immunity_period,
+            params.incentive_ratio,
+            params.max_allowed_uids,
+            params.max_allowed_weights,
+            params.max_stake,
+            params.min_allowed_weights,
+            params.max_weight_age,
+            params.min_stake,
+            params.name.clone(),
+            params.tempo,
+            params.trust_ratio,
+            params.vote_mode.clone(),
+            params.vote_threshold,
+        );
         let global_params = SubspaceModule::global_params();
         info!("global params {:?}", global_params);
         info!("subnet params {:?}", SubspaceModule::subnet_params(netuid));

--- a/pallets/subspace/tests/subnet.rs
+++ b/pallets/subspace/tests/subnet.rs
@@ -18,6 +18,9 @@ fn test_add_subnets() {
         let n = 20;
         let num_subnets: u16 = n;
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         for i in 0..num_subnets {
             assert_ok!(register_module(i, U256::from(i), stake_per_module));
             for j in 0..n {
@@ -159,6 +162,9 @@ fn test_emission_ratio() {
         let max_delta: f64 = 1.0;
         let _n: u16 = 10;
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         for i in 0..netuids.len() {
             let _key = U256::from(netuids[i]);
             let netuid = netuids[i];
@@ -197,6 +203,10 @@ fn test_set_max_allowed_uids_growing() {
         let mut max_uids: u16 = 100;
         let extra_uids: u16 = 10;
         let rounds = 10;
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         assert_ok!(register_module(netuid, U256::from(0), stake));
         SubspaceModule::set_max_registrations_per_block(max_uids + extra_uids * rounds);
         for i in 1..max_uids {
@@ -244,6 +254,9 @@ fn test_set_max_allowed_uids_shrinking() {
         let stake: u64 = 1_000_000_000;
         let max_uids: u16 = 100;
         let extra_uids: u16 = 20;
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         let mut n = SubspaceModule::get_subnet_n(netuid);
         info!("registering module {}", n);
@@ -329,6 +342,9 @@ fn test_set_max_allowed_modules() {
         let _extra_uids: u16 = 20;
         let max_allowed_modules: u16 = 100;
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         SubspaceModule::set_max_allowed_modules(max_allowed_modules);
         // set max_total modules
 
@@ -352,6 +368,8 @@ fn test_deregister_subnet_when_overflows_max_allowed_subnets() {
         let mut params = SubspaceModule::global_params();
         params.max_allowed_subnets = 3;
         SubspaceModule::set_global_params(params.clone());
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         assert_eq!(params.max_allowed_subnets, 3);
 

--- a/pallets/subspace/tests/voting.rs
+++ b/pallets/subspace/tests/voting.rs
@@ -16,6 +16,9 @@ fn test_subnet_porposal() {
         let keys = [U256::from(0), U256::from(1), U256::from(2)];
         let stakes = [1_000_000_000, 1_000_000_000, 1_000_000_000];
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         for (i, key) in keys.iter().enumerate() {
             assert_ok!(register_module(netuid, *key, stakes[i]));
         }
@@ -75,6 +78,9 @@ fn test_max_proposals() {
         let n = 100;
         let keys: Vec<U256> = (0..n).map(U256::from).collect();
         let mut stakes = vec![1_000_000_000; n];
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         // increase incrementally to avoid overflow
         let stakes =
             stakes.iter_mut().enumerate().map(|(i, x)| *x + i as u64).collect::<Vec<u64>>();
@@ -91,6 +97,7 @@ fn test_max_proposals() {
         );
         params.vote_mode = "stake".as_bytes().to_vec();
         params.max_proposals = (n / 2) as u64;
+        params.min_burn = 110_000_000;
         info!("params: {params:?}");
         SubspaceModule::set_global_params(params.clone());
 
@@ -169,6 +176,9 @@ fn test_global_porposal() {
         let keys = [U256::from(1), U256::from(2), U256::from(3)];
         let stakes = [1_000_000_000, 1_000_000_000, 1_000_000_000];
 
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
+
         // register on seperate subnets
         for (i, (key, stake)) in keys.iter().zip(stakes).enumerate() {
             assert_ok!(register_module(i as u16, *key, stake));
@@ -180,6 +190,7 @@ fn test_global_porposal() {
         let max_registrations_per_block = 1000;
 
         params.max_registrations_per_block = max_registrations_per_block;
+        params.min_burn = 110_000_000;
         assert_ok!(SubspaceModule::do_add_global_proposal(
             get_origin(keys[0]),
             params
@@ -217,6 +228,9 @@ fn test_unvote() {
         let netuid = 0;
         let keys = [U256::from(0), U256::from(1), U256::from(2)];
         let stakes = [1_000_000_000, 1_000_000_000, 1_000_000_000];
+
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
 
         for (i, key) in keys.iter().enumerate() {
             assert_ok!(register_module(netuid, *key, stakes[i]));

--- a/pallets/subspace/tests/weights.rs
+++ b/pallets/subspace/tests/weights.rs
@@ -17,6 +17,8 @@ fn test_weights_err_weights_vec_not_equal_size() {
     new_test_ext().execute_with(|| {
         let netuid: u16 = 0;
         let key_account_id = U256::from(55);
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         assert_ok!(register_module(netuid, key_account_id, 1_000_000_000));
         let _neuron_uid: u16 = SubspaceModule::get_uid_for_key(netuid, &key_account_id);
         let weights_keys: Vec<u16> = vec![1, 2, 3, 4, 5, 6];
@@ -37,6 +39,8 @@ fn test_weights_err_has_duplicate_ids() {
     new_test_ext().execute_with(|| {
         let key_account_id = U256::from(666);
         let netuid: u16 = 0;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         SubspaceModule::set_max_registrations_per_block(100);
 
         assert_ok!(register_module(netuid, key_account_id, 10));
@@ -85,6 +89,8 @@ fn test_set_weights_err_invalid_uid() {
     new_test_ext().execute_with(|| {
         let key_account_id = U256::from(55);
         let netuid: u16 = 0;
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         assert_ok!(register_module(netuid, key_account_id, 1_000_000_000));
         let _neuron_uid: u16 = SubspaceModule::get_uid_for_key(netuid, &key_account_id);
         let weight_keys: Vec<u16> = vec![9999]; // Does not exist
@@ -107,7 +113,8 @@ fn test_set_weight_not_enough_values() {
         let n = 100;
         SubspaceModule::set_max_registrations_per_block(n);
         let account_id = U256::from(0);
-
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         assert_ok!(register_module(netuid, account_id, 1_000_000_000));
 
         let _neuron_uid: u16 = SubspaceModule::get_uid_for_key(netuid, &account_id);
@@ -161,6 +168,8 @@ fn test_set_max_allowed_uids() {
         let n = 100;
         SubspaceModule::set_max_registrations_per_block(n);
         let account_id = U256::from(0);
+        // make sure that the results won´t get affected by burn
+        SubspaceModule::set_min_burn(0);
         assert_ok!(register_module(netuid, account_id, 1_000_000_000));
         let _neuron_uid: u16 = SubspaceModule::get_uid_for_key(netuid, &account_id);
         for i in 1..n {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -122,7 +122,10 @@ pub mod opaque {
     }
 }
 
-pub type Migrations = (pallet_subspace::migrations::v1::MigrateToV1<Runtime>,);
+pub type Migrations = (
+    pallet_subspace::migrations::v1::MigrateToV1<Runtime>,
+    pallet_subspace::migrations::v2::MigrateToV2<Runtime>,
+);
 // To learn more about runtime versioning, see:
 // https://docs.substrate.io/main-docs/build/upgrade#runtime-versioning
 #[sp_version::runtime_version]


### PR DESCRIPTION
# Changes
- local subnet burn + migration
- ensuring name safety regarding subnet naming
- fixing exploit-ability after reaching global maximum of modules

I honestly think that we should change the `subneset` to `subnetchangeset` and also add the update for it, what do you think @saiintbrisson ? 