### PR TITLE
fix: remove module from subnet if global limit is reached

### DIFF
--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -264,14 +264,14 @@ pub mod pallet {
 
     #[pallet::storage]
     // --- MAP (netuid) --> burn
-    pub(super) type Burn<T: Config> = StorageMap<_, Identity, u16, u64, ValueQuery>;
+    pub type Burn<T: Config> = StorageMap<_, Identity, u16, u64, ValueQuery>;
 
     #[pallet::type_value]
     pub fn DefaultMaxAllowedModules<T: Config>() -> u16 {
         10_000
     }
     #[pallet::storage] // --- ITEM ( max_allowed_modules )
-    pub(super) type MaxAllowedModules<T: Config> =
+    pub type MaxAllowedModules<T: Config> =
         StorageValue<_, u16, ValueQuery, DefaultMaxAllowedModules<T>>;
 
     #[pallet::type_value]

--- a/pallets/subspace/src/migrations.rs
+++ b/pallets/subspace/src/migrations.rs
@@ -179,6 +179,18 @@ pub mod v3 {
                     Trust::<T>::mutate(netuid, |v| v.push(0));
                     ValidatorPermits::<T>::mutate(netuid, |v| v.push(false));
                     ValidatorTrust::<T>::mutate(netuid, |v| v.push(0));
+
+                    // If the subnet has more modules than allowed, remove the lowest ones.
+
+                    let max_allowed = MaxAllowedUids::<T>::get(netuid);
+                    let currently_registered = Pallet::<T>::get_subnet_n(netuid);
+                    let overflown = currently_registered.saturating_sub(max_allowed);
+                    for _ in 0..overflown {
+                        Pallet::<T>::remove_module(
+                            netuid,
+                            Pallet::<T>::get_lowest_uid(netuid, false),
+                        );
+                    }
                 }
 
                 // Due to the incoming incentives refactoring, `max_stake` value

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -268,15 +268,11 @@ impl<T: Config> Pallet<T> {
 
     // get the least staked network
     pub fn least_staked_netuid() -> (u16, u64) {
-        let mut min_stake: u64 = u64::MAX;
-        let mut min_stake_netuid: u16 = Self::get_global_max_allowed_subnets() - 1;
-        for (netuid, net_stake) in <TotalStake<T> as IterableStorageMap<u16, u64>>::iter() {
-            if net_stake <= min_stake {
-                min_stake = net_stake;
-                min_stake_netuid = netuid;
-            }
-        }
-        (min_stake_netuid, min_stake)
+        TotalStake::<T>::iter().min_by_key(|(_, stake)| *stake).unwrap_or_else(|| {
+            let stake = u64::MAX;
+            let netuid = Self::get_global_max_allowed_subnets() - 1;
+            (netuid, stake)
+        })
     }
 
     pub fn address_vector(netuid: u16) -> Vec<Vec<u8>> {


### PR DESCRIPTION
Fixes a bug where, when the global module limit is reached, we began discarding modules globally before discarding them locally, meaning the limit for subnets is ignored.