### PR TITLE
fix: deregister wrong modules

### DIFF
--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -548,7 +548,7 @@ pub mod pallet {
     // =======================================
 
     #[pallet::storage] // --- DMAP ( netuid, module_key ) --> uid
-    pub(super) type Uids<T: Config> =
+    pub type Uids<T: Config> =
         StorageDoubleMap<_, Identity, u16, Blake2_128Concat, T::AccountId, u16, OptionQuery>;
 
     #[pallet::type_value]
@@ -567,9 +567,9 @@ pub mod pallet {
     pub type Address<T: Config> =
         StorageDoubleMap<_, Twox64Concat, u16, Twox64Concat, u16, Vec<u8>, ValueQuery>;
 
-    #[pallet::storage] // --- DMAP ( netuid, uid ) --> metadata_uri
+    #[pallet::storage] // --- DMAP ( netuid, module key ) --> metadata_uri
     pub type Metadata<T: Config> =
-        StorageDoubleMap<_, Twox64Concat, u16, Twox64Concat, u16, Vec<u8>>;
+        StorageDoubleMap<_, Twox64Concat, u16, Twox64Concat, T::AccountId, Vec<u8>>;
 
     #[pallet::type_value]
     pub fn DefaultDelegationFee<T: Config>() -> Percent {

--- a/pallets/subspace/src/registration.rs
+++ b/pallets/subspace/src/registration.rs
@@ -5,6 +5,7 @@ use super::*;
 use frame_support::pallet_prelude::DispatchResult;
 use frame_system::ensure_signed;
 
+use sp_core::Get;
 use sp_std::vec::Vec;
 
 impl<T: Config> Pallet<T> {
@@ -137,7 +138,7 @@ impl<T: Config> Pallet<T> {
         // If we do deregister slot.
         Self::reserve_module_slot(netuid);
 
-        let fee = DelegationFee::<T>::get(netuid, &module_key);
+        let fee = DefaultDelegationFee::<T>::get();
         // --- 8. Register the module and changeset.
         let module_changeset = ModuleChangeset::new(name, address, fee, metadata);
 

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -612,14 +612,9 @@ impl<T: Config> Pallet<T> {
         Keys::<T>::contains_key(netuid, uid)
     }
 
-    // Returns true if the key holds a slot on the network.
-    //
-    pub fn is_key_registered_on_network(netuid: u16, key: &T::AccountId) -> bool {
-        Uids::<T>::contains_key(netuid, key)
-    }
-
     pub fn key_registered(netuid: u16, key: &T::AccountId) -> bool {
         Uids::<T>::contains_key(netuid, key)
+            || Keys::<T>::iter_prefix_values(netuid).any(|k| &k == key)
     }
 
     pub fn is_key_registered_on_any_network(key: &T::AccountId) -> bool {

--- a/pallets/subspace/src/weights.rs
+++ b/pallets/subspace/src/weights.rs
@@ -30,7 +30,7 @@ impl<T: Config> Pallet<T> {
 
         // --- 4. Check to see if the key is registered to the passed network.
         ensure!(
-            Self::is_key_registered_on_network(netuid, &key),
+            Self::key_registered(netuid, &key),
             Error::<T>::NotRegistered
         );
 


### PR DESCRIPTION
Adds a logic to deregister duplicate keys in subnet modules, and a double check
to prevent this happening again.