### PR TITLE
refac(pallets/subspace): change logging system to tracing 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4876,7 +4876,6 @@ dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
- "log",
  "ndarray",
  "pallet-balances",
  "pallet-transaction-payment",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4896,6 +4896,7 @@ dependencies = [
  "sp-tracing",
  "sp-version",
  "substrate-fixed",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,9 @@ serde_with = { version = "=2.0.0", default-features = false, features = [
 serde-tuple-vec-map = { version = "1.0.1", default-features = false }
 smallvec = "1.6.1"
 tokio = "1.17.0"
+tracing = { version = "0.1.40", default-features = false, features = [
+    "attributes"
+] }
 
 codec = { version = "3.6.1", package = "parity-scale-codec", default-features = false, features = [
     "derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ clap = "4.4.6"
 futures = "0.3.21"
 jsonrpsee = "0.16.2"
 lazy_static = "1.4.0"
-log = { version = "0.4.14", default-features = false }
 memmap2 = "0.5.0"
 ndarray = { version = "0.15.0", default-features = false }
 rand = "0.8"

--- a/pallets/subspace/Cargo.toml
+++ b/pallets/subspace/Cargo.toml
@@ -43,6 +43,7 @@ serde_with.workspace = true
 sp-runtime.workspace = true
 sp-std.workspace = true
 log.workspace = true
+tracing.workspace = true 
 substrate-fixed.workspace = true
 pallet-transaction-payment.workspace = true
 ndarray.workspace = true

--- a/pallets/subspace/Cargo.toml
+++ b/pallets/subspace/Cargo.toml
@@ -42,7 +42,6 @@ serde_bytes.workspace = true
 serde_with.workspace = true
 sp-runtime.workspace = true
 sp-std.workspace = true
-log.workspace = true
 tracing.workspace = true 
 substrate-fixed.workspace = true
 pallet-transaction-payment.workspace = true

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -1483,38 +1483,38 @@ where
         if let Some((call_type, _transaction_fee, _who)) = maybe_pre {
             match call_type {
                 CallType::SetWeights => {
-                    log::debug!("Not Implemented!");
+                    tracing::debug!("Not Implemented!");
                 }
                 CallType::AddStake => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
 
                 CallType::AddStakeMultiple => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::RemoveStake => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::RemoveStakeMultiple => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::TransferStake => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::TransferStakeMultiple => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::TransferMultiple => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::AddNetwork => {
-                    log::debug!("Not Implemented! Need to add potential transaction fees here.");
+                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
                 }
                 CallType::Register => {
-                    log::debug!("Not Implemented!");
+                    tracing::debug!("Not Implemented!");
                 }
                 _ => {
-                    log::debug!("Not Implemented!");
+                    tracing::debug!("Not Implemented!");
                 }
             }
         }

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -891,7 +891,7 @@ pub mod pallet {
 
     #[pallet::genesis_build]
     impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
-        fn build(&self) {
+        fn build(&self) {           
             // Set initial total issuance from balances
             // Subnet config values
 

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -993,6 +993,7 @@ pub mod pallet {
     // Dispatchable functions must be annotated with a weight and must return a DispatchResult.
     #[pallet::call]
     impl<T: Config> Pallet<T> {
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn set_weights(
             origin: OriginFor<T>,
@@ -1003,6 +1004,7 @@ pub mod pallet {
             Self::do_set_weights(origin, netuid, uids, weights)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_stake(
             origin: OriginFor<T>,
@@ -1014,6 +1016,7 @@ pub mod pallet {
             Self::do_add_stake(origin, netuid, module_key, amount)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_stake_multiple(
             origin: OriginFor<T>,
@@ -1024,6 +1027,7 @@ pub mod pallet {
             Self::do_add_stake_multiple(origin, netuid, module_keys, amounts)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn remove_stake(
             origin: OriginFor<T>,
@@ -1034,6 +1038,7 @@ pub mod pallet {
             Self::do_remove_stake(origin, netuid, module_key, amount)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn remove_stake_multiple(
             origin: OriginFor<T>,
@@ -1044,6 +1049,7 @@ pub mod pallet {
             Self::do_remove_stake_multiple(origin, netuid, module_keys, amounts)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn transfer_stake(
             origin: OriginFor<T>,         // --- The account that is calling this function.
@@ -1055,6 +1061,7 @@ pub mod pallet {
             Self::do_transfer_stake(origin, netuid, module_key, new_module_key, amount)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn transfer_multiple(
             origin: OriginFor<T>, // --- The account that is calling this function.
@@ -1064,6 +1071,7 @@ pub mod pallet {
             Self::do_transfer_multiple(origin, destinations, amounts)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn update_module(
             origin: OriginFor<T>,
@@ -1083,6 +1091,7 @@ pub mod pallet {
             Self::do_update_module(origin, netuid, changeset)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn register(
             origin: OriginFor<T>,
@@ -1096,11 +1105,13 @@ pub mod pallet {
             Self::do_register(origin, network, name, address, stake, module_key, metadata)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn deregister(origin: OriginFor<T>, netuid: u16) -> DispatchResult {
             Self::do_deregister(origin, netuid)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_profit_shares(
             origin: OriginFor<T>,
@@ -1110,6 +1121,7 @@ pub mod pallet {
             Self::do_add_profit_shares(origin, keys, shares)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_to_whitelist(
             origin: OriginFor<T>,
@@ -1119,6 +1131,7 @@ pub mod pallet {
             Self::do_add_to_whitelist(origin, module_key, recommended_weight)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn remove_from_whitelist(
             origin: OriginFor<T>,
@@ -1127,6 +1140,7 @@ pub mod pallet {
             Self::do_remove_from_whitelist(origin, module_key)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn update_subnet(
             origin: OriginFor<T>,
@@ -1169,6 +1183,7 @@ pub mod pallet {
         }
 
         // Proposal Calls
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_global_proposal(
             origin: OriginFor<T>,
@@ -1224,6 +1239,7 @@ pub mod pallet {
             Self::do_add_global_proposal(origin, params)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_subnet_proposal(
             origin: OriginFor<T>,
@@ -1264,11 +1280,13 @@ pub mod pallet {
             Self::do_add_subnet_proposal(origin, netuid, params)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_custom_proposal(origin: OriginFor<T>, data: Vec<u8>) -> DispatchResult {
             Self::do_add_custom_proposal(origin, data)
         }
 
+        #[tracing::instrument(fields(origin, netuid))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn add_custom_subnet_proposal(
             origin: OriginFor<T>,
@@ -1278,6 +1296,7 @@ pub mod pallet {
             Self::do_add_custom_subnet_proposal(origin, netuid, data)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn vote_proposal(
             origin: OriginFor<T>,
@@ -1287,6 +1306,7 @@ pub mod pallet {
             Self::do_vote_proposal(origin, proposal_id, agree)
         }
 
+        #[tracing::instrument(fields(origin))]
         #[pallet::weight((Weight::zero(), DispatchClass::Normal, Pays::No))]
         pub fn unvote_proposal(origin: OriginFor<T>, proposal_id: u64) -> DispatchResult {
             Self::do_unregister_vote(origin, proposal_id)

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -891,7 +891,7 @@ pub mod pallet {
 
     #[pallet::genesis_build]
     impl<T: Config> BuildGenesisConfig for GenesisConfig<T> {
-        fn build(&self) {           
+        fn build(&self) {
             // Set initial total issuance from balances
             // Subnet config values
 
@@ -1502,38 +1502,19 @@ where
     ) -> Result<(), TransactionValidityError> {
         if let Some((call_type, _transaction_fee, _who)) = maybe_pre {
             match call_type {
-                CallType::SetWeights => {
-                    tracing::debug!("Not Implemented!");
+                CallType::AddStake
+                | CallType::AddStakeMultiple
+                | CallType::RemoveStake
+                | CallType::RemoveStakeMultiple
+                | CallType::TransferStake
+                | CallType::TransferStakeMultiple
+                | CallType::TransferMultiple
+                | CallType::AddNetwork => {
+                    tracing::debug!(
+                        "Not Implemented! Need to add potential transaction fees here."
+                    );
                 }
-                CallType::AddStake => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-
-                CallType::AddStakeMultiple => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::RemoveStake => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::RemoveStakeMultiple => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::TransferStake => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::TransferStakeMultiple => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::TransferMultiple => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::AddNetwork => {
-                    tracing::debug!("Not Implemented! Need to add potential transaction fees here.");
-                }
-                CallType::Register => {
-                    tracing::debug!("Not Implemented!");
-                }
-                _ => {
+                CallType::SetWeights | CallType::Register | _ => {
                     tracing::debug!("Not Implemented!");
                 }
             }

--- a/pallets/subspace/src/migrations.rs
+++ b/pallets/subspace/src/migrations.rs
@@ -36,11 +36,11 @@ pub mod v1 {
                 }
 
                 StorageVersion::new(1).put::<Pallet<T>>();
-                log::info!("Migrated DelegationFee to v1");
+                tracing::info!("Migrated DelegationFee to v1");
 
                 T::DbWeight::get().writes(1)
             } else {
-                log::info!("Storage v1 already updated");
+                tracing::info!("Storage v1 already updated");
                 Weight::zero()
             }
         }
@@ -93,7 +93,7 @@ pub mod v2 {
             let on_chain_version = StorageVersion::get::<Pallet<T>>();
 
             if on_chain_version == 1 {
-                log::info!("Migrating to V2");
+                tracing::info!("Migrating to V2");
 
                 // Migrate StakeFrom storage
                 for (netuid, module_key, stake_from) in old_storage::StakeFrom::<T>::iter() {
@@ -101,35 +101,35 @@ pub mod v2 {
                         stake_from.into_iter().collect();
                     StakeFrom::<T>::insert(netuid, module_key, new_stake_from);
                 }
-                log::info!("Migrated StakeFrom");
+                tracing::info!("Migrated StakeFrom");
 
                 // Migrate StakeTo storage
                 for (netuid, account_id, stake_to) in old_storage::StakeTo::<T>::iter() {
                     let new_stake_to: BTreeMap<T::AccountId, u64> = stake_to.into_iter().collect();
                     StakeTo::<T>::insert(netuid, account_id, new_stake_to);
                 }
-                log::info!("Migrated StakeTo");
+                tracing::info!("Migrated StakeTo");
 
                 for (netuid, mode) in old_storage::VoteModeSubnet::<T>::iter() {
                     let mode = match &mode[..] {
                         b"authority" => VoteMode::Authority,
                         b"stake" => VoteMode::Vote,
                         _ => {
-                            log::warn!("invalid vote mode {:?}", core::str::from_utf8(&mode));
+                            tracing::warn!("invalid vote mode {:?}", core::str::from_utf8(&mode));
                             VoteMode::Vote
                         }
                     };
                     VoteModeSubnet::<T>::insert(netuid, mode);
                 }
-                log::info!("Migrated VoteMode");
+                tracing::info!("Migrated VoteMode");
 
                 // Update the storage version to 2
                 StorageVersion::new(2).put::<Pallet<T>>();
 
-                log::info!("Migrated to v2");
+                tracing::info!("Migrated to v2");
                 T::DbWeight::get().reads_writes(1, 1)
             } else {
-                log::info!("Storage v2 already updated");
+                tracing::info!("Storage v2 already updated");
                 Weight::zero()
             }
         }
@@ -186,7 +186,7 @@ pub mod v3 {
                     // is in current model a security vounrability for cheap subnet DDOS.
                     // Make sure there is no subnet over target, if so deregister it.
                     if netuid >= SUBNET_CEILING {
-                        log::warn!("subnet {netuid} is over the limit ({SUBNET_CEILING}), deregistering {module_count} modules");
+                        tracing::warn!("subnet {netuid} is over the limit ({SUBNET_CEILING}), deregistering {module_count} modules");
                         Pallet::<T>::remove_subnet(netuid);
                         continue;
                     }
@@ -223,7 +223,7 @@ pub mod v3 {
                     let overflown = (module_count as u16).saturating_sub(max_allowed);
 
                     if overflown > 0 {
-                        log::warn!(
+                        tracing::warn!(
                             "netuid {netuid} has {overflown} overflown modules, deregistering"
                         );
                     }
@@ -231,7 +231,7 @@ pub mod v3 {
                     for _ in 0..overflown {
                         let module_uid = Pallet::<T>::get_lowest_uid(netuid, true);
                         Pallet::<T>::remove_module(netuid, module_uid);
-                        log::debug!("deregistered module {module_uid}");
+                        tracing::debug!("deregistered module {module_uid}");
                     }
 
                     netuids.insert(netuid);
@@ -240,7 +240,7 @@ pub mod v3 {
                     let keys_count = Keys::<T>::iter_key_prefix(netuid).count();
 
                     if uids_count != keys_count && netuid != 0 {
-                        log::warn!("{netuid}: subnet has inconsistent uids ({keys_count}) and keys ({uids_count}), deregistering...");
+                        tracing::warn!("{netuid}: subnet has inconsistent uids ({keys_count}) and keys ({uids_count}), deregistering...");
 
                         let mut keys = BTreeMap::new();
                         let mut broken_keys = BTreeSet::new();
@@ -253,7 +253,7 @@ pub mod v3 {
                             }
                         }
 
-                        log::warn!("{netuid}: broken uids {broken_uids:?}");
+                        tracing::warn!("{netuid}: broken uids {broken_uids:?}");
 
                         'outer: for key in broken_keys {
                             loop {
@@ -262,7 +262,7 @@ pub mod v3 {
                                 else {
                                     continue 'outer;
                                 };
-                                log::warn!(
+                                tracing::warn!(
                                     "{netuid}: removing duplicate key {key:?} with uid {uid}"
                                 );
                                 Pallet::<T>::remove_module(netuid, uid);
@@ -272,13 +272,13 @@ pub mod v3 {
                         let uids_count = Uids::<T>::iter_key_prefix(netuid).count();
                         let keys_count = Keys::<T>::iter_key_prefix(netuid).count();
                         if uids_count != keys_count {
-                            log::error!(
+                            tracing::error!(
                                 "{netuid}: subnet continues to have wrong number of uids and keys"
                             );
                         }
                     }
                 }
-                log::info!("Emission and consensus updated");
+                tracing::info!("Emission and consensus updated");
 
                 let mut gaps = BTreeSet::new();
                 for netuid in 0..netuids.last().copied().unwrap_or_default() {
@@ -287,8 +287,8 @@ pub mod v3 {
                     }
                 }
 
-                log::info!("Existing subnets:        {netuids:?}");
-                log::info!("Updated removed subnets: {gaps:?}");
+                tracing::info!("Existing subnets:        {netuids:?}");
+                tracing::info!("Updated removed subnets: {gaps:?}");
                 RemovedSubnets::<T>::set(gaps);
 
                 // -- GENERAL SUBNET PARAMS --
@@ -297,19 +297,19 @@ pub mod v3 {
                 // is no longer needed to be limited on the general subnet 0
                 let general_netuid = 0;
                 MaxStake::<T>::insert(general_netuid, u64::MAX);
-                log::info!("Min stake migrated");
+                tracing::info!("Min stake migrated");
 
                 // Due to the incoming subnet 0 whitelist, `min_allowed_weights`,
                 // can no longer be set to such high limit,
                 // as whitelist would not cover for it.
                 MinAllowedWeights::<T>::insert(general_netuid, 5); // Old 190 >
-                log::info!("Min allowed weights migrated");
+                tracing::info!("Min allowed weights migrated");
 
                 // Also make sure there is no weight age, as we are doing manual validation
                 MaxWeightAge::<T>::insert(general_netuid, u64::MAX);
-                log::info!("Max weight age migrated");
+                tracing::info!("Max weight age migrated");
 
-                log::info!("Setting subnet 0 to vote mode");
+                tracing::info!("Setting subnet 0 to vote mode");
                 VoteModeSubnet::<T>::set(0, VoteMode::Vote);
 
                 // GLOBAL PARAMS
@@ -322,16 +322,16 @@ pub mod v3 {
                 let dao_bot_account_id = ss58_to_account_id::<T>(dao_bot).unwrap();
 
                 Nominator::<T>::put(dao_bot_account_id); // Old empty
-                log::info!("Nominator migrated");
+                tracing::info!("Nominator migrated");
 
                 // Finally update
                 MaxAllowedSubnets::<T>::put(SUBNET_CEILING); // Old 256
-                log::info!("Max allowed subnets migrated");
+                tracing::info!("Max allowed subnets migrated");
 
                 // Migrate the proposal expiration to 12 days,
                 // as current timeframe is not sustainable.
                 ProposalExpiration::<T>::put(130000); // Old 32_000 blocks
-                log::info!("Proposal expiration migrated");
+                tracing::info!("Proposal expiration migrated");
 
                 // Cleanup the expired proposal from votes_for / against
                 // This logic is now automatically running onchain,
@@ -343,7 +343,7 @@ pub mod v3 {
                         Proposals::<T>::insert(proposal.id, proposal);
                     }
                 }
-                log::info!("Expired proposals migrated");
+                tracing::info!("Expired proposals migrated");
 
                 MaxWeightAge::<T>::iter_keys()
                     .filter(|n| !N::<T>::contains_key(n))
@@ -351,11 +351,11 @@ pub mod v3 {
 
                 // update the storage version
                 StorageVersion::new(3).put::<Pallet<T>>();
-                log::info!("Migrated subnets to v3");
+                tracing::info!("Migrated subnets to v3");
 
                 T::DbWeight::get().reads_writes(1, 1)
             } else {
-                log::info!("Storage v3 already updated");
+                tracing::info!("Storage v3 already updated");
                 Weight::zero()
             }
         }
@@ -377,11 +377,11 @@ pub mod v4 {
                 TrustRatio::<T>::set(0, 5);
 
                 StorageVersion::new(4).put::<Pallet<T>>();
-                log::info!("Migrated v4");
+                tracing::info!("Migrated v4");
 
                 T::DbWeight::get().writes(1)
             } else {
-                log::info!("Storage v4 already updated");
+                tracing::info!("Storage v4 already updated");
                 Weight::zero()
             }
         }

--- a/pallets/subspace/src/module.rs
+++ b/pallets/subspace/src/module.rs
@@ -155,7 +155,7 @@ impl<T: Config> Pallet<T> {
         let uid: u16 = Self::get_subnet_n(netuid);
         let block_number = Self::get_current_block_number();
 
-        log::debug!("append_module( netuid: {netuid:?} | uid: {key:?} | new_key: {uid:?})");
+        tracing::debug!("append_module( netuid: {netuid:?} | uid: {key:?} | new_key: {uid:?})");
 
         // 2. Apply the changeset
         changeset.apply::<T>(netuid, key.clone(), uid)?;
@@ -199,7 +199,7 @@ impl<T: Config> Pallet<T> {
         let replace_uid = n - 1;
         let replace_key: T::AccountId = Keys::<T>::get(netuid, replace_uid);
 
-        log::debug!(
+        tracing::debug!(
             "remove_module( netuid: {:?} | uid : {:?} | key: {:?} ) ",
             netuid,
             uid,

--- a/pallets/subspace/src/step.rs
+++ b/pallets/subspace/src/step.rs
@@ -10,7 +10,7 @@ pub mod yuma;
 impl<T: Config> Pallet<T> {
     pub fn block_step() {
         let block_number: u64 = Self::get_current_block_number();
-        log::debug!("block_step for block: {block_number:?}");
+        tracing::debug!("block_step for block: {block_number:?}");
         RegistrationsPerBlock::<T>::mutate(|val: &mut u16| *val = 0);
 
         // Execute proposals if any should be executed, this is done every 100 blocks.
@@ -42,7 +42,7 @@ impl<T: Config> Pallet<T> {
                 *queued += new_queued_emission;
                 *queued
             });
-            log::debug!("netuid {netuid} total pending emission: {emission_to_drain} (+{new_queued_emission:?}) ");
+            tracing::debug!("netuid {netuid} total pending emission: {emission_to_drain} (+{new_queued_emission:?}) ");
 
             if Self::blocks_until_next_epoch(netuid, tempo, block_number) > 0 {
                 continue;
@@ -69,7 +69,7 @@ impl<T: Config> Pallet<T> {
                         return Ok(());
                     };
 
-                    log::error!(
+                    tracing::error!(
                         "\
 failed to run yuma consensus algorithm: {err:?}, skipping this block. \
 {emission_to_drain} tokens will be emitted on the next epoch.\

--- a/pallets/subspace/src/voting.rs
+++ b/pallets/subspace/src/voting.rs
@@ -320,7 +320,7 @@ impl<T: Config> Pallet<T> {
             });
 
             if let Err(err) = res {
-                log::error!("failed to resolve proposal {proposal_id}: {err:?}");
+                tracing::error!("failed to resolve proposal {proposal_id}: {err:?}");
             }
         }
     }

--- a/pallets/subspace/tests/delegate_staking.rs
+++ b/pallets/subspace/tests/delegate_staking.rs
@@ -1,7 +1,7 @@
 mod mock;
 
 use frame_support::assert_ok;
-use log::info;
+use tracing::info;
 use mock::*;
 use pallet_subspace::Tempo;
 use sp_core::U256;

--- a/pallets/subspace/tests/delegate_staking.rs
+++ b/pallets/subspace/tests/delegate_staking.rs
@@ -1,11 +1,11 @@
 mod mock;
 
 use frame_support::assert_ok;
-use tracing::info;
 use mock::*;
 use pallet_subspace::Tempo;
 use sp_core::U256;
 use substrate_fixed::types::I64F64;
+use tracing::info;
 
 // /***********************************************************
 // 	staking::add_stake() tests

--- a/pallets/subspace/tests/mock.rs
+++ b/pallets/subspace/tests/mock.rs
@@ -11,7 +11,7 @@ use sp_runtime::{
     BuildStorage, DispatchResult,
 };
 
-use log::info;
+use tracing::info;
 
 type Block = frame_system::mocking::MockBlock<Test>;
 
@@ -238,7 +238,7 @@ pub fn delegate_register_module(
         None,
     );
 
-    log::info!("Register ok module: network: {name:?}, module_key: {module_key:?} key: {key:?}",);
+    tracing::info!("Register ok module: network: {name:?}, module_key: {module_key:?} key: {key:?}",);
 
     result
 }

--- a/pallets/subspace/tests/mock.rs
+++ b/pallets/subspace/tests/mock.rs
@@ -238,7 +238,9 @@ pub fn delegate_register_module(
         None,
     );
 
-    tracing::info!("Register ok module: network: {name:?}, module_key: {module_key:?} key: {key:?}",);
+    tracing::info!(
+        "Register ok module: network: {name:?}, module_key: {module_key:?} key: {key:?}",
+    );
 
     result
 }

--- a/pallets/subspace/tests/profit_share.rs
+++ b/pallets/subspace/tests/profit_share.rs
@@ -1,7 +1,7 @@
 mod mock;
 
 use frame_support::assert_ok;
-use log::info;
+use tracing::info;
 use mock::*;
 use sp_core::U256;
 use sp_std::vec;

--- a/pallets/subspace/tests/profit_share.rs
+++ b/pallets/subspace/tests/profit_share.rs
@@ -1,10 +1,10 @@
 mod mock;
 
 use frame_support::assert_ok;
-use tracing::info;
 use mock::*;
 use sp_core::U256;
 use sp_std::vec;
+use tracing::info;
 
 /* TO DO SAM: write test for LatuUpdate after it is set */
 #[test]

--- a/pallets/subspace/tests/registration.rs
+++ b/pallets/subspace/tests/registration.rs
@@ -6,7 +6,7 @@ use frame_support::{assert_err, assert_noop, assert_ok};
 use mock::*;
 use sp_core::U256;
 
-use log::info;
+use tracing::info;
 use pallet_subspace::{
     Emission, Error, MaxAllowedModules, MaxAllowedUids, MinStake, RemovedSubnets, Stake,
     SubnetNames, TotalSubnets, N,

--- a/pallets/subspace/tests/registration.rs
+++ b/pallets/subspace/tests/registration.rs
@@ -6,12 +6,12 @@ use frame_support::{assert_err, assert_noop, assert_ok};
 use mock::*;
 use sp_core::U256;
 
-use tracing::info;
 use pallet_subspace::{
     Emission, Error, MaxAllowedModules, MaxAllowedUids, MinStake, RemovedSubnets, Stake,
     SubnetNames, TotalSubnets, N,
 };
 use sp_runtime::{DispatchResult, Percent};
+use tracing::info;
 
 /********************************************
     subscribing::subscribe() tests

--- a/pallets/subspace/tests/staking.rs
+++ b/pallets/subspace/tests/staking.rs
@@ -1,7 +1,7 @@
 mod mock;
 
 use frame_support::{assert_noop, assert_ok};
-use log::info;
+use tracing::info;
 use mock::*;
 use pallet_subspace::Error;
 use sp_core::U256;

--- a/pallets/subspace/tests/staking.rs
+++ b/pallets/subspace/tests/staking.rs
@@ -1,11 +1,11 @@
 mod mock;
 
 use frame_support::{assert_noop, assert_ok};
-use tracing::info;
 use mock::*;
 use pallet_subspace::Error;
 use sp_core::U256;
 use substrate_fixed::types::I64F64;
+use tracing::info;
 
 // /***********************************************************
 // 	staking::add_stake() tests

--- a/pallets/subspace/tests/step_linear.rs
+++ b/pallets/subspace/tests/step_linear.rs
@@ -1,7 +1,7 @@
 mod mock;
 
 use frame_support::assert_ok;
-use log::info;
+use tracing::info;
 use mock::*;
 use pallet_subspace::{MaxAllowedWeights, MinAllowedWeights, Tempo};
 use sp_core::U256;

--- a/pallets/subspace/tests/step_linear.rs
+++ b/pallets/subspace/tests/step_linear.rs
@@ -1,10 +1,10 @@
 mod mock;
 
 use frame_support::assert_ok;
-use tracing::info;
 use mock::*;
 use pallet_subspace::{MaxAllowedWeights, MinAllowedWeights, Tempo};
 use sp_core::U256;
+use tracing::info;
 
 fn update_params(netuid: u16, tempo: u16, max_weights: u16, min_weights: u16) {
     Tempo::<Test>::insert(netuid, tempo);

--- a/pallets/subspace/tests/step_yuma.rs
+++ b/pallets/subspace/tests/step_yuma.rs
@@ -48,7 +48,7 @@ fn test_1_graph() {
         // Register general subnet
         assert_ok!(register_module(0, 10.into(), 1));
 
-        log::info!("test_1_graph:");
+        tracing::info!("test_1_graph:");
         let netuid: u16 = 1;
         let key = U256::from(0);
         let uid: u16 = 0;
@@ -98,7 +98,7 @@ fn test_1_graph() {
 fn test_10_graph() {
     /// Function for adding a nodes to the graph.
     fn add_node(netuid: u16, key: U256, uid: u16, stake_amount: u64) {
-        log::info!(
+        tracing::info!(
             "+Add net:{:?} hotkey:{:?} uid:{:?} stake_amount: {:?} subn: {:?}",
             netuid,
             key,
@@ -118,7 +118,7 @@ fn test_10_graph() {
         // Register general subnet
         assert_ok!(register_module(0, 10_000.into(), 1));
 
-        log::info!("test_10_graph");
+        tracing::info!("test_10_graph");
 
         // Build the graph with 10 items
         // each with 1 stake and self weights.

--- a/pallets/subspace/tests/subnet.rs
+++ b/pallets/subspace/tests/subnet.rs
@@ -1,7 +1,7 @@
 mod mock;
 
 use frame_support::assert_ok;
-use log::info;
+use tracing::info;
 use mock::*;
 use pallet_subspace::{Dividends, SubnetNames, N};
 use sp_core::U256;

--- a/pallets/subspace/tests/subnet.rs
+++ b/pallets/subspace/tests/subnet.rs
@@ -1,12 +1,12 @@
 mod mock;
 
 use frame_support::assert_ok;
-use tracing::info;
 use mock::*;
 use pallet_subspace::{Dividends, SubnetNames, N};
 use sp_core::U256;
 use sp_runtime::Percent;
 use sp_std::vec;
+use tracing::info;
 
 #[test]
 fn test_add_subnets() {


### PR DESCRIPTION
This PR:
- Removes all `log::` usages changing them to `tracing::`.
  - Adds `tracing` dependency.
  - Removes `log` dependency.
- Adds instrumentation to extrinsic methods via `#[tracing::instrument]`.