### PR TITLE
feat(pallets/subspace): add rate limiting to `set_weights` extrinsic

### DIFF
--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -280,6 +280,14 @@ pub mod pallet {
     pub type MaxAllowedWeightsGlobal<T> =
         StorageValue<_, u16, ValueQuery, DefaultMaxAllowedWeightsGlobal<T>>;
 
+    #[pallet::storage]
+    pub type MaximumSetWeightCallsPerEpoch<T: Config> =
+        StorageMap<_, Identity, u16, u16, ValueQuery>;
+
+    #[pallet::storage]
+    pub type SetWeightCallsPerEpoch<T: Config> =
+        StorageDoubleMap<_, Identity, u16, Identity, T::AccountId, u16, ValueQuery>;
+
     #[derive(Decode, Encode, PartialEq, Eq, Clone, Debug, TypeInfo)]
     #[scale_info(skip_type_params(T))]
     pub struct ModuleParams<T: Config> {
@@ -384,6 +392,7 @@ pub mod pallet {
                 min_stake: MinStakeGlobal::<T>::get(),
                 founder: DefaultFounder::<T>::get(),
                 vote_mode: DefaultVoteMode::<T>::get(),
+                maximum_set_weight_calls_per_epoch: 0,
             }
         }
     }
@@ -413,6 +422,7 @@ pub mod pallet {
         pub name: Vec<u8>,
         pub tempo: u16, // how many blocks to wait before rewarding models
         pub trust_ratio: u16,
+        pub maximum_set_weight_calls_per_epoch: u16,
         pub vote_mode: VoteMode,
     }
 
@@ -900,6 +910,8 @@ pub mod pallet {
         InvalidRecommendedWeight,
         InvalidMaxStake,
         ArithmeticError,
+
+        MaximumSetWeightsPerEpochReached,
     }
 
     // ==================
@@ -1179,6 +1191,7 @@ pub mod pallet {
             name: Vec<u8>,
             tempo: u16,
             trust_ratio: u16,
+            maximum_set_weight_calls_per_epoch: u16,
             vote_mode: VoteMode,
         ) -> DispatchResult {
             let params = SubnetParams {
@@ -1195,6 +1208,7 @@ pub mod pallet {
                 name,
                 tempo,
                 trust_ratio,
+                maximum_set_weight_calls_per_epoch,
                 vote_mode,
             };
 
@@ -1280,6 +1294,7 @@ pub mod pallet {
             max_weight_age: u64, // max age of a weight
             tempo: u16,          // how many blocks to wait before rewarding models
             trust_ratio: u16,    // missing comment
+            maximum_set_weight_calls_per_epoch: u16,
             vote_mode: VoteMode, // missing comment
         ) -> DispatchResult {
             let mut params = Self::subnet_params(netuid);
@@ -1296,6 +1311,7 @@ pub mod pallet {
             params.max_weight_age = max_weight_age;
             params.tempo = tempo;
             params.trust_ratio = trust_ratio;
+            params.maximum_set_weight_calls_per_epoch = maximum_set_weight_calls_per_epoch;
             params.vote_mode = vote_mode;
             Self::do_add_subnet_proposal(origin, netuid, params)
         }

--- a/pallets/subspace/src/step.rs
+++ b/pallets/subspace/src/step.rs
@@ -48,6 +48,9 @@ impl<T: Config> Pallet<T> {
                 continue;
             }
 
+            // Clearing `set_weight` rate limiter values.
+            let _ = SetWeightCallsPerEpoch::<T>::clear_prefix(netuid, u32::MAX, None);
+
             let has_enough_stake_for_yuma = || {
                 let subnet_stake = Self::get_total_subnet_stake(netuid) as u128;
                 let total_stake = Self::total_stake() as u128;

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -44,6 +44,15 @@ impl<T: Config> SubnetChangeset<T> {
         IncentiveRatio::<T>::insert(netuid, self.params.incentive_ratio);
         VoteModeSubnet::<T>::insert(netuid, self.params.vote_mode);
 
+        if self.params.maximum_set_weight_calls_per_epoch == 0 {
+            MaximumSetWeightCallsPerEpoch::<T>::remove(netuid);
+        } else {
+            MaximumSetWeightCallsPerEpoch::<T>::insert(
+                netuid,
+                &self.params.maximum_set_weight_calls_per_epoch,
+            );
+        }
+
         Pallet::<T>::deposit_event(Event::SubnetParamsUpdated(netuid));
 
         Ok(())
@@ -263,6 +272,7 @@ impl<T: Config> Pallet<T> {
             name: SubnetNames::<T>::get(netuid),
             trust_ratio: TrustRatio::<T>::get(netuid),
             incentive_ratio: IncentiveRatio::<T>::get(netuid),
+            maximum_set_weight_calls_per_epoch: MaximumSetWeightCallsPerEpoch::<T>::get(netuid),
             vote_mode: VoteModeSubnet::<T>::get(netuid),
         }
     }

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -49,7 +49,7 @@ impl<T: Config> SubnetChangeset<T> {
         } else {
             MaximumSetWeightCallsPerEpoch::<T>::insert(
                 netuid,
-                &self.params.maximum_set_weight_calls_per_epoch,
+                self.params.maximum_set_weight_calls_per_epoch,
             );
         }
 

--- a/pallets/subspace/src/weights.rs
+++ b/pallets/subspace/src/weights.rs
@@ -34,6 +34,19 @@ impl<T: Config> Pallet<T> {
             Error::<T>::NotRegistered
         );
 
+        let max_set_weights = MaximumSetWeightCallsPerEpoch::<T>::get(netuid);
+        if max_set_weights != 0 {
+            let set_weight_uses = SetWeightCallsPerEpoch::<T>::mutate(netuid, &key, |value| {
+                *value = value.saturating_add(1);
+                *value
+            });
+
+            ensure!(
+                set_weight_uses <= max_set_weights,
+                Error::<T>::MaximumSetWeightsPerEpochReached
+            );
+        }
+
         // --- 5. Get the module uid of associated key on network netuid.
         let uid: u16 = Self::get_uid_for_key(netuid, &key);
 

--- a/pallets/subspace/tests/voting.rs
+++ b/pallets/subspace/tests/voting.rs
@@ -343,6 +343,7 @@ fn creates_subnet_params_proposal_correctly_and_is_approved() {
             max_weight_age,
             tempo,
             trust_ratio,
+            maximum_set_weight_calls_per_epoch,
             vote_mode,
         } = params.clone();
 
@@ -362,6 +363,7 @@ fn creates_subnet_params_proposal_correctly_and_is_approved() {
             max_weight_age,
             tempo,
             trust_ratio,
+            maximum_set_weight_calls_per_epoch,
             vote_mode,
         )
         .expect("failed to create proposal");


### PR DESCRIPTION
This PR:

> Implements rate limiting per subnet validator per epoch (`Tempo` on `block_step`).
> The mechanism is: a validator on a subnet can call `set_weights` up to to X times per epoch (**note**: it's rate limited by the number of _calls_ and not by weights set).
> 
> 1. A maximum number of calls to `set_weights` is defined by the storage map `MaximumSetWeightCallsPerEpoch (netuid -> number of calls per epoch as u16)`.
> 2. Each call to `set_weights` on a epoch increases the double storage map `SetWeightCallsPerEpoch (netuid, module key -> number of calls this epoch as u16)` until it reaches `MaximumSetWeightCallsPerEpoch` after which we return a new error variant `MaximumSetWeightsPerEpochReached` (or a better name, this is just an example). If `MaximumSetWeightsPerEpochReached` is not set, or is zero, we don't enforce the rate limit.
> 3. `MaximumSetWeightsPerEpochReached` must be configurable through subnet proposals (and must be part of SubnetParams). If a user sets it to zero, we remove the subnet uid from the map.
> 4. Every time the subnet reaches the epoch, we clear its `SetWeightCallsPerEpoch`.
>
> Extra: adds rate limit tests

Closes #70 