### PR TITLE
chore: migrate existing burn values to v6

### DIFF
--- a/pallets/subspace/src/migrations.rs
+++ b/pallets/subspace/src/migrations.rs
@@ -446,8 +446,12 @@ pub mod v6 {
             TargetRegistrationsPerInterval::<T>::set(5);
             log::info!("TargetRegistrationsPerInterval set to 5");
 
-            MinBurn::<T>::set(10_000_000_000);
-            log::info!("MinBurn set to 10 (10_000_000_000)");
+            let min_burn = 10_000_000_000;
+            MinBurn::<T>::set(min_burn);
+            for (netuid, burn) in Burn::<T>::iter() {
+                Burn::<T>::set(netuid, min_burn.max(burn));
+            }
+            log::info!("MinBurn set to 10 (10_000_000_000) and migrated subnets");
 
             let old_val = AdjustmentAlpha::<T>::get();
             let new_val = AdjustmentAlpha::<T>::mutate(|value: &mut u64| {


### PR DESCRIPTION
Migrates existing burns to the new MinBurn value