### PR TITLE
feat: adding subnet application cost

### DIFF
--- a/pallets/subspace/src/global.rs
+++ b/pallets/subspace/src/global.rs
@@ -33,6 +33,8 @@ impl<T: Config> Pallet<T> {
                                                        * blocks */
             proposal_participation_threshold: Self::get_proposal_participation_threshold(), /* denominated
                                                                                             in percent of the overall network stake */
+            // s0
+            general_subnet_application_cost: Self::get_general_subnet_application_cost(),
         }
     }
 
@@ -116,6 +118,11 @@ impl<T: Config> Pallet<T> {
 
         // Proposal checks
         ensure!(params.proposal_cost > 0, Error::<T>::InvalidProposalCost);
+
+        ensure!(
+            params.general_subnet_application_cost > 0,
+            Error::<T>::InvalidGeneralSubnetApplicationCost
+        );
 
         ensure!(
             params.proposal_expiration % 100 == 0, // for computational reasons
@@ -248,6 +255,10 @@ impl<T: Config> Pallet<T> {
 
     pub fn get_proposal_participation_threshold() -> Percent {
         ProposalParticipationThreshold::<T>::get()
+    }
+
+    pub fn get_general_subnet_application_cost() -> u64 {
+        GeneralSubnetApplicationCost::<T>::get()
     }
 
     pub fn get_max_registrations_per_block() -> u16 {

--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -331,6 +331,8 @@ pub mod pallet {
         pub proposal_cost: u64,
         pub proposal_expiration: u32,
         pub proposal_participation_threshold: Percent,
+        // s0 governance
+        pub general_subnet_application_cost: u64,
 
         // founder share
         pub floor_founder_share: u8,
@@ -890,6 +892,7 @@ pub mod pallet {
         InvalidIncentiveRatio,
 
         InvalidProposalCost,
+        InvalidGeneralSubnetApplicationCost,
         InvalidProposalExpiration,
         InvalidProposalParticipationThreshold,
         InsufficientStake,
@@ -1012,6 +1015,15 @@ pub mod pallet {
     #[pallet::storage]
     pub(super) type ProposalParticipationThreshold<T: Config> =
         StorageValue<_, Percent, ValueQuery, DefaultProposalParticipationThreshold<T>>;
+
+    #[pallet::type_value]
+    pub fn DefaultGeneralSubnetApplicationCost<T: Config>() -> u64 {
+        1_000_000_000 // 1_000 $COMAI
+    }
+
+    #[pallet::storage]
+    pub type GeneralSubnetApplicationCost<T: Config> =
+        StorageValue<_, u64, ValueQuery, DefaultGeneralSubnetApplicationCost<T>>;
 
     #[pallet::storage]
     pub type Proposals<T: Config> = StorageMap<_, Identity, u64, Proposal<T>>;
@@ -1247,6 +1259,7 @@ pub mod pallet {
             proposal_participation_threshold: Percent, /*  minimum stake of the overall network
                                        * stake,
                                        *  in order for proposal to get executed */
+            general_subnet_application_cost: u64,
         ) -> DispatchResult {
             let mut params = Self::global_params();
             params.burn_rate = burn_rate;
@@ -1271,6 +1284,7 @@ pub mod pallet {
             params.proposal_cost = proposal_cost;
             params.proposal_expiration = proposal_expiration;
             params.proposal_participation_threshold = proposal_participation_threshold;
+            params.general_subnet_application_cost = general_subnet_application_cost;
             Self::do_add_global_proposal(origin, params)
         }
 

--- a/pallets/subspace/src/voting.rs
+++ b/pallets/subspace/src/voting.rs
@@ -196,7 +196,7 @@ impl<T: Config> Pallet<T> {
     ) -> DispatchResult {
         // Check if the proposer has enough balance
         // re use the same value as for proposals
-        let application_cost = ProposalCost::<T>::get();
+        let application_cost = GeneralSubnetApplicationCost::<T>::get();
 
         ensure!(
             Self::has_enough_balance(&key, application_cost),

--- a/pallets/subspace/tests/registration.rs
+++ b/pallets/subspace/tests/registration.rs
@@ -209,7 +209,7 @@ fn test_whitelist() {
         params.curator = key;
         SubspaceModule::set_global_params(params);
 
-        let proposal_cost = SubspaceModule::get_proposal_cost();
+        let proposal_cost = SubspaceModule::get_general_subnet_application_cost();
         let data = "test".as_bytes().to_vec();
 
         add_balance(key, proposal_cost + 1);

--- a/pallets/subspace/tests/voting.rs
+++ b/pallets/subspace/tests/voting.rs
@@ -58,6 +58,7 @@ fn creates_global_params_proposal_correctly_and_expires() {
             proposal_cost,
             proposal_expiration,
             proposal_participation_threshold,
+            general_subnet_application_cost,
         } = params.clone();
 
         SubspaceModule::add_global_proposal(
@@ -84,6 +85,7 @@ fn creates_global_params_proposal_correctly_and_expires() {
             proposal_cost,
             proposal_expiration,
             proposal_participation_threshold,
+            general_subnet_application_cost,
         )
         .expect("failed to create proposal");
 
@@ -159,6 +161,7 @@ fn creates_global_params_proposal_correctly_and_is_approved() {
             proposal_cost,
             proposal_expiration,
             proposal_participation_threshold,
+            general_subnet_application_cost,
         } = params.clone();
 
         SubspaceModule::add_global_proposal(
@@ -185,6 +188,7 @@ fn creates_global_params_proposal_correctly_and_is_approved() {
             proposal_cost,
             proposal_expiration,
             proposal_participation_threshold,
+            general_subnet_application_cost,
         )
         .expect("failed to create proposal");
 
@@ -253,6 +257,7 @@ fn creates_global_params_proposal_correctly_and_is_refused() {
             proposal_cost,
             proposal_expiration,
             proposal_participation_threshold,
+            general_subnet_application_cost,
         } = GlobalParams {
             min_burn: 100_000_000,
             ..original.clone()
@@ -282,6 +287,7 @@ fn creates_global_params_proposal_correctly_and_is_refused() {
             proposal_cost,
             proposal_expiration,
             proposal_participation_threshold,
+            general_subnet_application_cost,
         )
         .expect("failed to create proposal");
 


### PR DESCRIPTION
This PR intents to add a `custom_application_cost` to subnet 0, as the current one of 10_000, using proposal cost, is too high. There should be a unique *global parameter* for application cost to subnet 0.