### PR TITLE
feat: Moving Yuma BondsMA under SubnetParams

### DIFF
--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -393,6 +393,7 @@ pub mod pallet {
                 founder: DefaultFounder::<T>::get(),
                 vote_mode: DefaultVoteMode::<T>::get(),
                 maximum_set_weight_calls_per_epoch: 0,
+                bonds_ma: DefaultBondsMovingAverage::<T>::get(),
             }
         }
     }
@@ -424,6 +425,8 @@ pub mod pallet {
         pub trust_ratio: u16,
         pub maximum_set_weight_calls_per_epoch: u16,
         pub vote_mode: VoteMode,
+        // consensus
+        pub bonds_ma: u64,
     }
 
     #[pallet::type_value]
@@ -1196,6 +1199,7 @@ pub mod pallet {
             trust_ratio: u16,
             maximum_set_weight_calls_per_epoch: u16,
             vote_mode: VoteMode,
+            bonds_ma: u64,
         ) -> DispatchResult {
             let params = SubnetParams {
                 founder,
@@ -1213,6 +1217,7 @@ pub mod pallet {
                 trust_ratio,
                 maximum_set_weight_calls_per_epoch,
                 vote_mode,
+                bonds_ma,
             };
 
             let changeset = SubnetChangeset::update(netuid, params)?;
@@ -1299,6 +1304,7 @@ pub mod pallet {
             trust_ratio: u16,    // missing comment
             maximum_set_weight_calls_per_epoch: u16,
             vote_mode: VoteMode, // missing comment
+            bonds_ma: u64,
         ) -> DispatchResult {
             let mut params = Self::subnet_params(netuid);
             params.founder = founder;
@@ -1316,6 +1322,7 @@ pub mod pallet {
             params.trust_ratio = trust_ratio;
             params.maximum_set_weight_calls_per_epoch = maximum_set_weight_calls_per_epoch;
             params.vote_mode = vote_mode;
+            params.bonds_ma = bonds_ma;
             Self::do_add_subnet_proposal(origin, netuid, params)
         }
 

--- a/pallets/subspace/src/migrations.rs
+++ b/pallets/subspace/src/migrations.rs
@@ -435,7 +435,7 @@ pub mod v6 {
                 return Weight::zero();
             }
 
-            log::info!("Migrating v6");
+            log::info!("Migrating to v6");
 
             MaxAllowedWeightsGlobal::<T>::set(1024);
             log::info!("Global MaxAllowedWeights set to 1024");
@@ -444,9 +444,9 @@ pub mod v6 {
             FounderShare::<T>::set(0, 12);
             log::info!("FounderShare of Subnet 0 set to 12");
 
-            // Target of registrations per day, per subnet, is set to 135
-            TargetRegistrationsPerInterval::<T>::set(5);
-            log::info!("TargetRegistrationsPerInterval set to 5");
+            // Target of registrations per day, per subnet, is set to 100
+            TargetRegistrationsPerInterval::<T>::set(4);
+            log::info!("TargetRegistrationsPerInterval set to 4");
 
             let floor_founder_share = FloorFounderShare::<T>::get() as u16;
             for (subnet_id, value) in FounderShare::<T>::iter() {
@@ -454,8 +454,8 @@ pub mod v6 {
             }
             log::info!("All founder share set to minimum floor founder share");
 
-            TargetRegistrationsInterval::<T>::set(400);
-            log::info!("TargetRegistrationsInterval set to 400");
+            TargetRegistrationsInterval::<T>::set(432);
+            log::info!("TargetRegistrationsInterval set to 432");
 
             let min_burn = 10_000_000_000;
             MinBurn::<T>::set(min_burn);

--- a/pallets/subspace/src/subnet.rs
+++ b/pallets/subspace/src/subnet.rs
@@ -274,6 +274,7 @@ impl<T: Config> Pallet<T> {
             incentive_ratio: IncentiveRatio::<T>::get(netuid),
             maximum_set_weight_calls_per_epoch: MaximumSetWeightCallsPerEpoch::<T>::get(netuid),
             vote_mode: VoteModeSubnet::<T>::get(netuid),
+            bonds_ma: BondsMovingAverage::<T>::get(netuid),
         }
     }
 

--- a/pallets/subspace/tests/subnet.rs
+++ b/pallets/subspace/tests/subnet.rs
@@ -234,6 +234,7 @@ fn test_set_max_allowed_uids_shrinking() {
             params.trust_ratio,
             params.maximum_set_weight_calls_per_epoch,
             params.vote_mode,
+            params.bonds_ma,
         );
         let global_params = SubspaceModule::global_params();
         info!("global params {:?}", global_params);
@@ -812,6 +813,7 @@ fn test_update_same_name() {
             params.trust_ratio,
             params.maximum_set_weight_calls_per_epoch,
             params.vote_mode,
+            params.bonds_ma,
         );
 
         dbg!(SubnetNames::<Test>::get(netuid));

--- a/pallets/subspace/tests/voting.rs
+++ b/pallets/subspace/tests/voting.rs
@@ -345,6 +345,7 @@ fn creates_subnet_params_proposal_correctly_and_is_approved() {
             trust_ratio,
             maximum_set_weight_calls_per_epoch,
             vote_mode,
+            bonds_ma,
         } = params.clone();
 
         SubspaceModule::add_subnet_proposal(
@@ -365,6 +366,7 @@ fn creates_subnet_params_proposal_correctly_and_is_approved() {
             trust_ratio,
             maximum_set_weight_calls_per_epoch,
             vote_mode,
+            bonds_ma,
         )
         .expect("failed to create proposal");
 


### PR DESCRIPTION
## What changed
- Some subnet owners would like to set their `BondsMovingAverage` to different values, as it better fits their model. Currently we are hardcoding it.
- After looking at more subnets and testing, the current aim at `135` registrations per day -> per subnet. Still seems too much, and likely would not represent the demand accordingly, that's why we are setting it to `100`. The goal is to eventually move this parameter until a subnet specific ones, not a global one, but we would prefer to wait for a different subnet pricing mechanism with this move.