### PR TITLE
refac(pallets/subpsace): add refactors around iter casts (#64)

### DIFF
--- a/pallets/subspace/src/lib.rs
+++ b/pallets/subspace/src/lib.rs
@@ -534,6 +534,15 @@ pub mod pallet {
     #[pallet::storage]
     pub type GlobalDaoTreasury<T: Config> = StorageValue<_, u64, ValueQuery>;
 
+    #[pallet::type_value]
+    pub fn DefaultDaoTreasuryDistribution<T: Config>() -> Percent {
+        Percent::from_percent(50u8)
+    }
+
+    #[pallet::storage]
+    pub type DaoTreasuryDistribution<T: Config> =
+        StorageValue<_, Percent, ValueQuery, DefaultDaoTreasuryDistribution<T>>;
+
     // VOTING MODE
     #[pallet::type_value]
     pub fn DefaultFloorFounderShare<T: Config>() -> u8 {

--- a/pallets/subspace/src/step/yuma.rs
+++ b/pallets/subspace/src/step/yuma.rs
@@ -205,11 +205,15 @@ impl<T: Config> YumaCalc<T> {
         let mut emissions: EmissionMap<T> = Default::default();
         let mut emitted = 0;
 
-        for (module_key, mut server_emission, mut validator_emission) in result {
-            if module_key.0 == self.founder_key.0 {
-                server_emission = server_emission.saturating_add(self.founder_emission);
-            }
+        if self.founder_emission > 0 {
+            Pallet::<T>::add_balance_to_account(
+                &self.founder_key.0,
+                Pallet::<T>::u64_to_balance(self.founder_emission).unwrap_or_default(),
+            );
+            emitted += self.founder_emission;
+        }
 
+        for (module_key, server_emission, mut validator_emission) in result {
             let mut increase_stake = |account_key: &AccountKey<T>, amount: u64| {
                 Pallet::<T>::increase_stake(self.netuid, &account_key.0, &module_key.0, amount);
                 *emissions

--- a/pallets/subspace/tests/mock.rs
+++ b/pallets/subspace/tests/mock.rs
@@ -305,7 +305,6 @@ macro_rules! update_params {
             $($f: $v),+,
             ..SubspaceModule::subnet_params($netuid)
         };
-        dbg!(&params);
         ::pallet_subspace::subnet::SubnetChangeset::<Test>::update($netuid, params).unwrap().apply($netuid).unwrap();
     }};
     ($netuid:expr => $params:expr) => {{

--- a/pallets/subspace/tests/subnet.rs
+++ b/pallets/subspace/tests/subnet.rs
@@ -351,9 +351,6 @@ fn test_emission_distribution_novote() {
         let expected_stake_change_below = 0;
         let change_tolerance = to_nano(22) as i64; // we tolerate 22 token difference (due to rounding)
 
-        dbg!(expected_stake_change_general);
-        dbg!(expected_stake_change_yuma);
-        dbg!(expected_stake_change_below);
         // first register the general subnet
         assert_ok!(register_module(
             netuid_general,
@@ -372,6 +369,10 @@ fn test_emission_distribution_novote() {
             stake_below_threshold
         ));
 
+        FounderShare::<Test>::set(0, 0);
+        FounderShare::<Test>::set(1, 0);
+        FounderShare::<Test>::set(2, 0);
+
         step_block(blocks_in_day);
 
         let general_netuid_stake =
@@ -386,10 +387,6 @@ fn test_emission_distribution_novote() {
         let below_threshold_netuid_stake =
             (below_threshold_netuid_stake as f64 / 100.0).round() * 100.0;
 
-        dbg!(general_netuid_stake);
-        dbg!(yuma_netuid_stake);
-        dbg!(below_threshold_netuid_stake);
-
         let start_stake = stake_general + stake_yuma + stake_below_threshold;
         let end_day_stake = to_nano(
             (general_netuid_stake + yuma_netuid_stake + below_threshold_netuid_stake) as u64,
@@ -399,8 +396,6 @@ fn test_emission_distribution_novote() {
 
         // Check the expected difference for the general subnet
         let general_stake_change = to_nano(general_netuid_stake as u64) - stake_general;
-        dbg!(general_stake_change);
-        dbg!(expected_stake_change_general);
         assert!(
             (general_stake_change as i64 - expected_stake_change_general as i64).abs()
                 <= change_tolerance
@@ -495,6 +490,10 @@ fn test_yuma_self_vote() {
 
         // Calculate the expected daily change in total stake
         let expected_stake_change = to_nano(250_000);
+
+        FounderShare::<Test>::set(0, 0);
+        FounderShare::<Test>::set(1, 0);
+        FounderShare::<Test>::set(2, 0);
 
         step_block(blocks_in_day);
 


### PR DESCRIPTION
Adds a treasury distribution system for subnet owners above the stake threshold and deposits founder shares directly into the account of founders.

Closes #77 and #76.