### PR TITLE
fix: multiply percentage instead of dividing

### DIFF
--- a/pallets/governance/src/proposal.rs
+++ b/pallets/governance/src/proposal.rs
@@ -583,7 +583,7 @@ pub fn get_reward_allocation<T: crate::Config>(
         I92F36::from_num(governance_config.max_proposal_reward_treasury_allocation);
 
     let mut allocation = treasury_balance
-        .checked_div(allocation_percentage)
+        .checked_mul(allocation_percentage)
         .unwrap_or_default()
         .min(max_allocation);
     if n > 0 {


### PR DESCRIPTION
# Pull Request Checklist

Before submitting this PR, please make sure:

- [x] You have run `cargo clippy` and addressed any warnings
- [ ] You have added appropriate tests (if applicable)
- [x] You have updated the documentation (if applicable)
- [x] You have reviewed your own code
- [x] You have updated changelog (if applicable)

## Description

This PR fixes a bug on vote reward distribution that would divide the treasury allocation by the vote reward allocation percentage instead of multiplying it.

## Related Issues

